### PR TITLE
Disable mean mass subtraction

### DIFF
--- a/InputParameters/input_params_list.cpp
+++ b/InputParameters/input_params_list.cpp
@@ -35,6 +35,7 @@ namespace
     {"pixelmaps_on","0","Input one or more pixelized density maps"},
     {"pixelmaps_input_file","surfacedensity.fits","Density map(s) to be read in as main lens.  This can be a single map (*.fits) or a file with a list of fits files."},
     {"pixelmap_padding_factor","4","The factor by which the map is zero padded when doing FFTS."},
+    {"pixelmap_zeromean","true","By default the mean surface density is subtracted from the map. Set to false to turn this off"},
     // MultiDarkMap lenses
     //{"PixelizedDensityMap_input_file", "PixelizedMapFiles.txt", "list of MOKA FITS files for MultiDark-like simulations"},
     

--- a/MultiPlane/MOKAfits.cpp
+++ b/MultiPlane/MOKAfits.cpp
@@ -268,18 +268,48 @@ void LensHaloMassMap::readMap(){
     map->Dlens = cosmo.angDist(0.,map->zlens);  // physical
     double inarcsec  = 180./M_PI/map->Dlens*60.*60.;
     double pixLMpc,pixelunit;
-    try {
+    try{
       // physical size in degrees
       h0->readKey("PHYSICALSIZE",map->boxlarcsec);
       map->boxlarcsec=map->boxlarcsec*60.*60.;
       pixLMpc = map->boxlarcsec/npixels/inarcsec;
       map->boxlMpc = pixLMpc*npixels;
+    }
+    catch(CCfits::HDU::NoSuchKeyword) {
+      try{
+        // physical size in degrees
+        h0->readKey("PHYSICAL",map->boxlarcsec);
+        map->boxlarcsec=map->boxlarcsec*60.*60.;
+        pixLMpc = map->boxlarcsec/npixels/inarcsec;
+        map->boxlMpc = pixLMpc*npixels;
+      }
+      catch(CCfits::HDU::NoSuchKeyword) {
+        std::cerr << "fits mass map must have header keywords:" << std::endl
+        << " REDSHIFT - redshift of map plane" << std::endl
+        //<< " DLOW - ?? Mpc/h" << std::endl
+        //<< " DLUP - ?? Mpc/h" << std::endl
+        << " PHYSICALSIZE - size of map in the x-direction (degrees)" << std::endl
+        << " PIXELUNIT - pixel units in solar masses" << std::endl;
+        
+        std::cout << " unable to read map PIXELUNITS" << std::endl;
+        exit(1);
+        
+      }
+      
+    }
+    
+    
+    try {
+      h0->readKey("PIXELUNIT",pixelunit);
+      pixelunit=pixelunit/pixLMpc/pixLMpc;
+    }
+    catch(CCfits::HDU::NoSuchKeyword) {
+      
       try {
-        h0->readKey("PIXELUNIT",pixelunit);
+        h0->readKey("PIXELUNI",pixelunit);
         pixelunit=pixelunit/pixLMpc/pixLMpc;
       }
       catch(CCfits::HDU::NoSuchKeyword) {
-        
         std::cerr << "fits mass map must have header keywords:" << std::endl
         << " REDSHIFT - redshift of map plane" << std::endl
         //<< " DLOW - ?? Mpc/h" << std::endl
@@ -291,518 +321,525 @@ void LensHaloMassMap::readMap(){
         exit(1);
       }
     }
-    catch(CCfits::HDU::NoSuchKeyword) {
+      /*catch(CCfits::HDU::NoSuchKeyword) {
+        
+        std::cerr << "fits mass map should have header keywords:" << std::endl
+        << " REDSHIFT - redshift of map plane" << std::endl
+        //<< " DLOW - ?? Mpc/h" << std::endl
+        //<< " DLUP - ?? Mpc/h" << std::endl
+        << " PHYSICALSIZE - size of map in the x-direction (degrees)" << std::endl
+        << " PIXELUNIT - pixel units in solar masses" << std::endl;
+        
+        std::cout << "unable to read map PHYSICALSIZE" << std::endl;
+        std::cout << "assuming is the MultiDark file" << std::endl;
+        map->boxlarcsec = 8.7*60.*60.;    // W1 x-field of view
+        // map->boxlarcsec = 5.5*60.*60.;    // W4 x-field of view
+        pixLMpc = map->boxlarcsec/npixels/inarcsec;
+        map->boxlMpc = pixLMpc*npixels;
+        pixelunit = 1.e+10/cosmo.gethubble()/pixLMpc/pixLMpc; // by hand
+      }*/
       
-      std::cerr << "fits mass map should have header keywords:" << std::endl
-      << " REDSHIFT - redshift of map plane" << std::endl
-      //<< " DLOW - ?? Mpc/h" << std::endl
-      //<< " DLUP - ?? Mpc/h" << std::endl
-      << " PHYSICALSIZE - size of map in the x-direction (degrees)" << std::endl
-      << " PIXELUNIT - pixel units in solar masses" << std::endl;
       
-      std::cout << "unable to read map PHYSICALSIZE" << std::endl;
-      std::cout << "assuming is the MultiDark file" << std::endl;
-      map->boxlarcsec = 8.7*60.*60.;    // W1 x-field of view
-      // map->boxlarcsec = 5.5*60.*60.;    // W4 x-field of view
-      pixLMpc = map->boxlarcsec/npixels/inarcsec;
-      map->boxlMpc = pixLMpc*npixels;
-      pixelunit = 1.e+10/cosmo.gethubble()/pixLMpc/pixLMpc; // by hand
-    }
     
-    
-    double avkappa = 0;
-    
-    // made square // need to be
-    // 1. take the part located in the left side
-    //for(int i=0;i<npixels;i++) for(int j=0;j<npixels;j++){
-    //    map->convergence[i+npixels*j] = mapbut[i+map->nx*j]*pixelunit;
-    //    avkappa += map->convergence[i+npixels*j];
-    //  }
-    // 2. take the part located in the right side
-    // for(int i=0;i<npixels;i++) for(int j=0;j<npixels;j++){
-    //    map->convergence[i+npixels*j] = mapbut[(map->nx-npixels+i)+map->nx*j]*pixelunit;
-    //    avkappa += map->convergence[i+npixels*j];
-    //  }
-    // avkappa /= (npixels*npixels);
+      // made square // need to be
+      // 1. take the part located in the left side
+      //for(int i=0;i<npixels;i++) for(int j=0;j<npixels;j++){
+      //    map->convergence[i+npixels*j] = mapbut[i+map->nx*j]*pixelunit;
+      //    avkappa += map->convergence[i+npixels*j];
+      //  }
+      // 2. take the part located in the right side
+      // for(int i=0;i<npixels;i++) for(int j=0;j<npixels;j++){
+      //    map->convergence[i+npixels*j] = mapbut[(map->nx-npixels+i)+map->nx*j]*pixelunit;
+      //    avkappa += map->convergence[i+npixels*j];
+      //  }
+      // avkappa /= (npixels*npixels);
     
     for(int i=0;i<map->nx;i++) for(int j=0;j<map->ny;j++){
       map->convergence[i+map->nx*j] *= pixelunit;
-      avkappa += map->convergence[i+map->nx*j];
     }
-    avkappa /= (map->nx*map->ny);
     
-    for(int i=0;i<map->nx;i++) for(int j=0;j<map->ny;j++){
-      map->convergence[i+map->nx*j] = (map->convergence[i+map->nx*j] - avkappa);
+    if(zeromean){
+      double avkappa = 0;
+
+      for(int i=0;i<map->nx;i++) for(int j=0;j<map->ny;j++){
+        avkappa += map->convergence[i+map->nx*j];
+      }
+      avkappa /= (map->nx*map->ny);
+      
+      for(int i=0;i<map->nx;i++) for(int j=0;j<map->ny;j++){
+        map->convergence[i+map->nx*j] = (map->convergence[i+map->nx*j] - avkappa);
+      }
     }
-    // kappa is not divided by the critical surface density
-    // they don't need to be preprocessed by fact
-    // create alpha and gamma arrays by FFT
-    // valid only to force the map to be square map->nx = map->ny = npixels;
+    
+      // kappa is not divided by the critical surface density
+      // they don't need to be preprocessed by fact
+      // create alpha and gamma arrays by FFT
+      // valid only to force the map to be square map->nx = map->ny = npixels;
 #ifdef ENABLE_FFTW
-    std:: cout << "  preProcessing Map " << std:: endl;
-    // reducing the size of the maps
-    // carlo test begin
-    /*
-     int nl = 2048;
-     std:: cout << " resizing the map to " << nl << std:: endl;
-     std:: vector<double> xh,xl;
-     fill_linear(xh,npixels,0.,1.);
-     fill_linear(xl,nl,0.,1.);
-     std:: valarray<float> kl(nl*nl);
-     for(int i=0;i<nl;i++) for(int j=0;j<nl;j++){
-     double xi = xl[i];
-     double yi = xl[j];
-     double ki = getMapVal(map->convergence,npixels,xi,yi,xh,xh);
-     kl[i+nl*j] = ki;
-     if(ki!=ki){
-     std:: cout << xi << "  " << yi << "  " << ki << std:: endl;
-     exit(1);
-     }
-	    }
-     std:: cout << "  done " << std:: endl;
-     map->nx = map->ny = nl;
-     map->convergence.resize(nl*nl);
-     std:: cout << "  remapping " << std:: endl;
-     for(int i=0;i<nl;i++) for(int j=0;j<nl;j++){
-     map->convergence[i+nl*j] = kl[i+nl*j];
-	    }
-     */
-    // carlo test end
-    PreProcessFFTWMap();
+      std:: cout << "  preProcessing Map " << std:: endl;
+      // reducing the size of the maps
+      // carlo test begin
+      /*
+       int nl = 2048;
+       std:: cout << " resizing the map to " << nl << std:: endl;
+       std:: vector<double> xh,xl;
+       fill_linear(xh,npixels,0.,1.);
+       fill_linear(xl,nl,0.,1.);
+       std:: valarray<float> kl(nl*nl);
+       for(int i=0;i<nl;i++) for(int j=0;j<nl;j++){
+       double xi = xl[i];
+       double yi = xl[j];
+       double ki = getMapVal(map->convergence,npixels,xi,yi,xh,xh);
+       kl[i+nl*j] = ki;
+       if(ki!=ki){
+       std:: cout << xi << "  " << yi << "  " << ki << std:: endl;
+       exit(1);
+       }
+       }
+       std:: cout << "  done " << std:: endl;
+       map->nx = map->ny = nl;
+       map->convergence.resize(nl*nl);
+       std:: cout << "  remapping " << std:: endl;
+       for(int i=0;i<nl;i++) for(int j=0;j<nl;j++){
+       map->convergence[i+nl*j] = kl[i+nl*j];
+       }
+       */
+      // carlo test end
+      PreProcessFFTWMap();
 #else
-    std::cout << "Please enable the preprocessor flag ENABLE_FFTW !" << std::endl;
-    exit(1);
+      std::cout << "Please enable the preprocessor flag ENABLE_FFTW !" << std::endl;
+      exit(1);
 #endif
-  }
-  
-  // std:: cout << map->boxlMpc << "  " << map->boxlarcsec << std:: endl;
-  
-  for(size_t i=0;i<map->convergence.size();++i){
-    assert(map->convergence[i] == map->convergence[i]);
-  }
-#else
-  std::cout << "Please enable the preprocessor flag ENABLE_FITS !" << std::endl;
-  exit(1);
-#endif
-}
-
-
-/**
- * \brief write the fits file of the new MOKA map from the structure map
- */
-void LensHaloMassMap::writeImage(std::string filename){
-#ifdef ENABLE_FITS
-  long naxis=2;
-  long naxes[2]={map->nx,map->ny};
-  
-  std::auto_ptr<FITS> fout(0);
-  
-  try{
-    fout.reset(new FITS(filename,FLOAT_IMG,naxis,naxes));
-  }
-  catch(FITS::CantCreate){
-    std::cout << "Unable to open fits file " << filename << std::endl;
-    ERROR_MESSAGE();
-    exit(1);
-  }
-  
-  std::vector<long> naxex(2);
-  naxex[0]=map->nx;
-  naxex[1]=map->ny;
-  
-  PHDU *phout=&fout->pHDU();
-  
-  phout->write( 1,map->nx*map->ny,map->convergence );
-  
-  phout->addKey ("SIDEL",map->boxlarcsec,"arcsec");
-  phout->addKey ("SIDEL2",map->boxlMpc,"Mpc/h");
-  phout->addKey ("ZLENS",map->zlens,"lens redshift");
-  phout->addKey ("ZSOURCE",map->zsource, "source redshift");
-  phout->addKey ("OMEGA",map->omegam,"omega matter");
-  phout->addKey ("LAMBDA",map->omegal,"omega lamda");
-  phout->addKey ("H",map->h,"hubble/100");
-  phout->addKey ("W",map->wq,"dark energy equation of state parameter");
-  phout->addKey ("MSTAR",map->mstar,"stellar mass of the BCG in Msun/h");
-  phout->addKey ("MVIR",map->m,"virial mass of the halo in Msun/h");
-  phout->addKey ("CONCENTRATION",map->c,"NFW concentration");
-  phout->addKey ("DL",map->Dlens,"Mpc/h");
-  phout->addKey ("DLS",map->DLS,"Mpc/h");
-  phout->addKey ("DS",map->DS,"Mpc/h");
-  
-  ExtHDU *eh1=fout->addImage("gamma1", FLOAT_IMG, naxex);
-  eh1->write(1,map->nx*map->ny,map->gamma1);
-  ExtHDU *eh2=fout->addImage("gamma2", FLOAT_IMG, naxex);
-  eh2->write(1,map->nx*map->ny,map->gamma2);
-  ExtHDU *eh3=fout->addImage("gamma3", FLOAT_IMG, naxex);
-  eh3->write(1,map->nx*map->ny,map->gamma3);
-  
-  std::cout << *phout << std::endl;
-#else
-  std::cout << "Please enable the preprocessor flag ENABLE_FITS !" << std::endl;
-  exit(1);
-#endif
-}
-
-/**
- * routine used by fof to link nearby grid cell points
- */
-void make_friendship(int ii,int ji,int np,std:: vector<int> &friends, std:: vector<double> &pointdist){
-  for(int jj=0;jj<np;jj++){
-    if(friends[ji+np*jj]!=0){
-      if(friends[ji+np*jj]<0){
-        friends[ii+np*jj]=-(ii+1);
-      }
-      else{
-        friends[ii+np*jj]=(ii+1);
-      }
-      friends[ji+np*jj]=0;
     }
+    
+    // std:: cout << map->boxlMpc << "  " << map->boxlarcsec << std:: endl;
+    
+    for(size_t i=0;i<map->convergence.size();++i){
+      assert(map->convergence[i] == map->convergence[i]);
+    }
+#else
+    std::cout << "Please enable the preprocessor flag ENABLE_FITS !" << std::endl;
+    exit(1);
+#endif
   }
-  friends[ii+np*ji]=-(ii+1);
-}
-
-/*
- * given a a set of grid points xci and yci and an interpixeld distance l return the id of the
- * fof group nearest to the centre
- */
-
-int fof(double l,std:: vector<double> xci, std:: vector<double> yci, std:: vector<int> &groupid){
-  int np = xci.size();
-  std:: vector<int> friends(np*np);
-  std:: vector<double> pointdist(np*np);
-  for(int ii = 0;ii<np; ii++) for(int ji = 0;ji<np; ji++){
-    pointdist[ii+np*ji] = sqrt( pow(xci[ii] - xci[ji],2) + pow(yci[ii] - yci[ji],2));
-    groupid[ii] = 0;
-    friends[ii+np*ji]=0;
+  
+  
+  /**
+   * \brief write the fits file of the new MOKA map from the structure map
+   */
+  void LensHaloMassMap::writeImage(std::string filename){
+#ifdef ENABLE_FITS
+    long naxis=2;
+    long naxes[2]={map->nx,map->ny};
+    
+    std::auto_ptr<FITS> fout(0);
+    
+    try{
+      fout.reset(new FITS(filename,FLOAT_IMG,naxis,naxes));
+    }
+    catch(FITS::CantCreate){
+      std::cout << "Unable to open fits file " << filename << std::endl;
+      ERROR_MESSAGE();
+      exit(1);
+    }
+    
+    std::vector<long> naxex(2);
+    naxex[0]=map->nx;
+    naxex[1]=map->ny;
+    
+    PHDU *phout=&fout->pHDU();
+    
+    phout->write( 1,map->nx*map->ny,map->convergence );
+    
+    phout->addKey ("SIDEL",map->boxlarcsec,"arcsec");
+    phout->addKey ("SIDEL2",map->boxlMpc,"Mpc/h");
+    phout->addKey ("ZLENS",map->zlens,"lens redshift");
+    phout->addKey ("ZSOURCE",map->zsource, "source redshift");
+    phout->addKey ("OMEGA",map->omegam,"omega matter");
+    phout->addKey ("LAMBDA",map->omegal,"omega lamda");
+    phout->addKey ("H",map->h,"hubble/100");
+    phout->addKey ("W",map->wq,"dark energy equation of state parameter");
+    phout->addKey ("MSTAR",map->mstar,"stellar mass of the BCG in Msun/h");
+    phout->addKey ("MVIR",map->m,"virial mass of the halo in Msun/h");
+    phout->addKey ("CONCENTRATION",map->c,"NFW concentration");
+    phout->addKey ("DL",map->Dlens,"Mpc/h");
+    phout->addKey ("DLS",map->DLS,"Mpc/h");
+    phout->addKey ("DS",map->DS,"Mpc/h");
+    
+    ExtHDU *eh1=fout->addImage("gamma1", FLOAT_IMG, naxex);
+    eh1->write(1,map->nx*map->ny,map->gamma1);
+    ExtHDU *eh2=fout->addImage("gamma2", FLOAT_IMG, naxex);
+    eh2->write(1,map->nx*map->ny,map->gamma2);
+    ExtHDU *eh3=fout->addImage("gamma3", FLOAT_IMG, naxex);
+    eh3->write(1,map->nx*map->ny,map->gamma3);
+    
+    std::cout << *phout << std::endl;
+#else
+    std::cout << "Please enable the preprocessor flag ENABLE_FITS !" << std::endl;
+    exit(1);
+#endif
   }
-  for(int ii=0;ii<np;ii++) for(int ji = 0;ji<np; ji++){
-    if(pointdist[ii+np*ji]<=1.5*l) friends[ii+np*ji] = ii+1;
+  
+  /**
+   * routine used by fof to link nearby grid cell points
+   */
+  void make_friendship(int ii,int ji,int np,std:: vector<int> &friends, std:: vector<double> &pointdist){
+    for(int jj=0;jj<np;jj++){
+      if(friends[ji+np*jj]!=0){
+        if(friends[ji+np*jj]<0){
+          friends[ii+np*jj]=-(ii+1);
+        }
+        else{
+          friends[ii+np*jj]=(ii+1);
+        }
+        friends[ji+np*jj]=0;
+      }
+    }
+    friends[ii+np*ji]=-(ii+1);
   }
-  for(int ii=0;ii<np;ii++){
-    int r = 0;
-    while(r==0){
-      r=1;
-      for(int ji=0;ji<np;ji++){
-        if(friends[ii+np*ji]>0){
-          if(ii!=ji){
-            make_friendship(ii,ji,np,friends,pointdist);
-            r=0;
+  
+  /*
+   * given a a set of grid points xci and yci and an interpixeld distance l return the id of the
+   * fof group nearest to the centre
+   */
+  
+  int fof(double l,std:: vector<double> xci, std:: vector<double> yci, std:: vector<int> &groupid){
+    int np = xci.size();
+    std:: vector<int> friends(np*np);
+    std:: vector<double> pointdist(np*np);
+    for(int ii = 0;ii<np; ii++) for(int ji = 0;ji<np; ji++){
+      pointdist[ii+np*ji] = sqrt( pow(xci[ii] - xci[ji],2) + pow(yci[ii] - yci[ji],2));
+      groupid[ii] = 0;
+      friends[ii+np*ji]=0;
+    }
+    for(int ii=0;ii<np;ii++) for(int ji = 0;ji<np; ji++){
+      if(pointdist[ii+np*ji]<=1.5*l) friends[ii+np*ji] = ii+1;
+    }
+    for(int ii=0;ii<np;ii++){
+      int r = 0;
+      while(r==0){
+        r=1;
+        for(int ji=0;ji<np;ji++){
+          if(friends[ii+np*ji]>0){
+            if(ii!=ji){
+              make_friendship(ii,ji,np,friends,pointdist);
+              r=0;
+            }
           }
         }
       }
     }
-  }
-  for(int ii=0;ii<np;ii++){
-    int p=0;
-    for(int ji=0;ji<np;ji++){
-      if(friends[ji+np*ii]!=0) p++;
-      if(p==2){
-        std:: cout << ji << "  " << ii << ":  "  << friends[ji+np*ii] << "  " << friends[ii+np*ji] << std:: endl;
-        exit(1);
+    for(int ii=0;ii<np;ii++){
+      int p=0;
+      for(int ji=0;ji<np;ji++){
+        if(friends[ji+np*ii]!=0) p++;
+        if(p==2){
+          std:: cout << ji << "  " << ii << ":  "  << friends[ji+np*ii] << "  " << friends[ii+np*ji] << std:: endl;
+          exit(1);
+        }
       }
     }
-  }
-  // count the particles in each group
-  int kt = 0;
-  int ng= 0;
-  std:: vector<double> distcentre;
-  std:: vector<int> idgroup;
-  for(int ii=0;ii<np;ii++){
-    int k = 0;
-    double xcm=0;
-    double ycm=0;
-    for(int ji=0;ji<np;ji++){
-      if(friends[ii+np*ji]!=0){
-        k++;
-        groupid[ji]=ii+1;
-        xcm += xci[ji];
-        ycm += yci[ji];
+    // count the particles in each group
+    int kt = 0;
+    int ng= 0;
+    std:: vector<double> distcentre;
+    std:: vector<int> idgroup;
+    for(int ii=0;ii<np;ii++){
+      int k = 0;
+      double xcm=0;
+      double ycm=0;
+      for(int ji=0;ji<np;ji++){
+        if(friends[ii+np*ji]!=0){
+          k++;
+          groupid[ji]=ii+1;
+          xcm += xci[ji];
+          ycm += yci[ji];
+        }
       }
+      if(k>4){
+        ng++;
+        xcm/=k;
+        ycm/=k;
+        distcentre.push_back(sqrt(xcm*xcm+ycm*ycm));
+        idgroup.push_back(ii+1);
+        // std:: cout << "  " << ii+1 << "  " << k << "   " << sqrt(xcm*xcm+ycm*ycm) << std:: endl;
+      }
+      kt = kt + k;
     }
-    if(k>4){
-      ng++;
-      xcm/=k;
-      ycm/=k;
-      distcentre.push_back(sqrt(xcm*xcm+ycm*ycm));
-      idgroup.push_back(ii+1);
-      // std:: cout << "  " << ii+1 << "  " << k << "   " << sqrt(xcm*xcm+ycm*ycm) << std:: endl;
+    if(kt != np){
+      std:: cout << " number of screaned particles : " << kt << std:: endl;
+      std:: cout << " differes from the number of particles : " << np << std:: endl;
+      std:: cout << " number of group found : " << ng << std:: endl;
+      std:: cout << "     " << std:: endl;
+      std:: cout << " I will STOP here!!! " << std:: endl;
+      exit(1);
     }
-    kt = kt + k;
+    if(idgroup.size()>0){
+      std:: vector<double>::iterator it = min_element(distcentre.begin(), distcentre.end());
+      int minpos = idgroup[distance(distcentre.begin(), it)];
+      // std:: cout << " nearest to the centre " << minpos << std:: endl;
+      return minpos;
+    }
+    else return 0;
+    /* Make a histogram of the data */
+    /*
+     std::vector< int > histogram(np,0);
+     std::vector< int >::iterator it = groupid.begin();
+     while(it != groupid.end()) histogram[*it++]++;
+     // Print out the frequencies of the values in v
+     std::copy(histogram.begin(),histogram.end(),std::ostream_iterator< int >(std::cout, " "));
+     std::cout << std::endl;
+     // Find the mode
+     int mode = std::max_element(histogram.begin(),histogram.end()) - histogram.begin();
+     return mode;
+     */
   }
-  if(kt != np){
-    std:: cout << " number of screaned particles : " << kt << std:: endl;
-    std:: cout << " differes from the number of particles : " << np << std:: endl;
-    std:: cout << " number of group found : " << ng << std:: endl;
-    std:: cout << "     " << std:: endl;
-    std:: cout << " I will STOP here!!! " << std:: endl;
-    exit(1);
-  }
-  if(idgroup.size()>0){
-    std:: vector<double>::iterator it = min_element(distcentre.begin(), distcentre.end());
-    int minpos = idgroup[distance(distcentre.begin(), it)];
-    // std:: cout << " nearest to the centre " << minpos << std:: endl;
-    return minpos;
-  }
-  else return 0;
-  /* Make a histogram of the data */
-  /*
-   std::vector< int > histogram(np,0);
-   std::vector< int >::iterator it = groupid.begin();
-   while(it != groupid.end()) histogram[*it++]++;
-   // Print out the frequencies of the values in v
-   std::copy(histogram.begin(),histogram.end(),std::ostream_iterator< int >(std::cout, " "));
-   std::cout << std::endl;
-   // Find the mode
-   int mode = std::max_element(histogram.begin(),histogram.end()) - histogram.begin();
-   return mode;
+  
+  /**
+   * \brief pre-process sourface mass density map computing deflection angles and shear in FFT,
+   *  generalized to work with rectangular maps
    */
-}
-
-/**
- * \brief pre-process sourface mass density map computing deflection angles and shear in FFT,
- *  generalized to work with rectangular maps
- */
-
-void LensHaloMassMap::PreProcessFFTWMap(){
+  
+  void LensHaloMassMap::PreProcessFFTWMap(){
 #ifdef ENABLE_FFTW
-  // initialize the quantities and does the zeropadding
-  //int npix_filter = 0;   // filter the map if you want on a given number of pixels: CHECK IT NOT IMPLEMENTED YET
-  
-  // size of the new map in x and y directions, factor by which each size is increased
-  int Nnx=int(zerosize*map->nx);
-  int Nny=int(zerosize*map->ny);
-  double Nboxlx = map->boxlMpc*zerosize;
-  double Nboxly = map->boxlMpc*zerosize/map->nx*map->ny;
-  
-  std:: valarray<float> Nmap;
-  try{
-    Nmap.resize( Nnx*Nny );
-  }catch(std::exception &e){
-    std::cerr << "exception thrown in LensHaloMassMap::PreProcessFFTWMap(): " << e.what() << std::endl;
-  }
-  // assume locate in a rectangular map and build up the new one
-  for( int i=0; i<Nnx; i++ ) for( int j=0; j<Nny; j++ ){
-    Nmap[i+Nnx*j]=0;
-    if(i>=int(Nnx/2-map->nx/2) && i<int(Nnx/2+map->nx/2) && j>=int(Nny/2-map->ny/2) && j<int(Nny/2+map->ny/2)){
-      int ii = i-int(Nnx/2-map->nx/2);
-      int jj = j-int(Nny/2-map->ny/2);
+    // initialize the quantities and does the zeropadding
+    //int npix_filter = 0;   // filter the map if you want on a given number of pixels: CHECK IT NOT IMPLEMENTED YET
+    
+    // size of the new map in x and y directions, factor by which each size is increased
+    int Nnx=int(zerosize*map->nx);
+    int Nny=int(zerosize*map->ny);
+    double Nboxlx = map->boxlMpc*zerosize;
+    double Nboxly = map->boxlMpc*zerosize/map->nx*map->ny;
+    
+    std:: valarray<float> Nmap;
+    try{
+      Nmap.resize( Nnx*Nny );
+    }catch(std::exception &e){
+      std::cerr << "exception thrown in LensHaloMassMap::PreProcessFFTWMap(): " << e.what() << std::endl;
+    }
+    // assume locate in a rectangular map and build up the new one
+    for( int i=0; i<Nnx; i++ ) for( int j=0; j<Nny; j++ ){
+      Nmap[i+Nnx*j]=0;
+      if(i>=int(Nnx/2-map->nx/2) && i<int(Nnx/2+map->nx/2) && j>=int(Nny/2-map->ny/2) && j<int(Nny/2+map->ny/2)){
+        int ii = i-int(Nnx/2-map->nx/2);
+        int jj = j-int(Nny/2-map->ny/2);
+        
+        if(ii>=map->nx || jj>=map->ny){
+          std::cout << " 1 error mapping " << ii << "  " << jj << std::endl;
+          exit(1);
+        }
+        if(ii<0 || jj<0){
+          std::cout << " 2 error mapping " << ii << "  " << jj << std::endl;
+          exit(1);
+        }
+        Nmap[i+Nnx*j]=map->convergence[ii+map->nx*jj];
+      }
+    }
+    
+    double *dNmap=new double[Nnx*Nny];
+    double *input=new double[Nnx*Nny];
+    fftw_complex *fNmap=new fftw_complex[Nny*(Nnx/2+1)];
+    fftw_complex *output=new fftw_complex[Nny*(Nnx/2+1)];
+    for(int k=0;k<Nnx*Nny;k++) dNmap[k] = double(Nmap[k]);
+    fftw_plan p;
+    p=fftw_plan_dft_r2c_2d(Nny,Nnx,input,output,FFTW_ESTIMATE);
+    
+    for(int i=0;i<Nnx*Nny;i++) input[i] = dNmap[i];
+    fftw_execute( p );
+    for(int i=0; i<Nny*(Nnx/2+1);i++){
+      fNmap[i][0] = output[i][0];
+      fNmap[i][1] = output[i][1];
+    }
+    delete[] input;
+    delete[] output;
+    delete[] dNmap;
+    fftw_destroy_plan(p);
+    
+    // fourier space
+    // std:: cout << " allocating fourier space maps " << std:: endl;
+    
+    
+    fftw_complex *fphi   = new fftw_complex[Nny*(Nnx/2+1)];
+    // build modes for each pixel in the fourier space
+    for( int i=0; i<Nnx/2+1; i++ ){
+      double kx=double(i);
+      kx=kx*2.*M_PI/Nboxlx;
+      for( int j=0; j<Nny; j++ ){
+        double ky=(j<Nny/2)?double(j):double(j-Nny);
+        ky=ky*2.*M_PI/Nboxly;
+        double k2 = kx*kx+ky*ky;
+        //smooth if you want to IMPLEMENT
+        // if(npix_filter>0){
+        // fNmap[j+(Nnpixels/2+1)*i][0] = fNmap[j+(Nnpixels/2+1)*i][0]*exp(-k2/sigmag/sigmag/2.);
+        // fNmap[j+(Nnpixels/2+1)*i][1] = fNmap[j+(Nnpixels/2+1)*i][1]*exp(-k2/sigmag/sigmag/2.);
+        // }
+        
+        // fphi
+        fphi[i+(Nnx/2+1)*j][0]= -2.*fNmap[i+(Nnx/2+1)*j][0]/k2;
+        fphi[i+(Nnx/2+1)*j][1]= -2.*fNmap[i+(Nnx/2+1)*j][1]/k2;
+        // null for k2 = 0 no divergence
+        if(k2 == 0){
+          fphi[i+(Nnx/2+1)*j][0] = 0.;
+          fphi[i+(Nnx/2+1)*j][1] = 0.;
+        }
+      }
+    }
+    
+    delete[] fNmap;
+    
+    
+    fftw_complex *fft= new fftw_complex[Nny*(Nnx/2+1)];
+    double *realsp = new double[Nnx*Nny];
+    //fftw_plan pp = fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
+    fftw_plan pp = fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_MEASURE);
+    
+    // alpha1
+    {
       
-      if(ii>=map->nx || jj>=map->ny){
-        std::cout << " 1 error mapping " << ii << "  " << jj << std::endl;
-        exit(1);
+      // build modes for each pixel in the fourier space
+      for( int i=0; i<Nnx/2+1; i++ ){
+        double kx=double(i);
+        kx=kx*2.*M_PI/Nboxlx;
+        for( int j=0; j<Nny; j++ ){
+          double ky=(j<Nny/2)?double(j):double(j-Nny);
+          ky=ky*2.*M_PI/Nboxly;
+          
+          fft[i+(Nnx/2+1)*j][0] = -kx*fphi[i+(Nnx/2+1)*j][1];
+          fft[i+(Nnx/2+1)*j][1] =  kx*fphi[i+(Nnx/2+1)*j][0];
+        }
       }
-      if(ii<0 || jj<0){
-        std::cout << " 2 error mapping " << ii << "  " << jj << std::endl;
-        exit(1);
-      }
-      Nmap[i+Nnx*j]=map->convergence[ii+map->nx*jj];
-    }
-  }
-  
-  double *dNmap=new double[Nnx*Nny];
-  double *input=new double[Nnx*Nny];
-  fftw_complex *fNmap=new fftw_complex[Nny*(Nnx/2+1)];
-  fftw_complex *output=new fftw_complex[Nny*(Nnx/2+1)];
-  for(int k=0;k<Nnx*Nny;k++) dNmap[k] = double(Nmap[k]);
-  fftw_plan p;
-  p=fftw_plan_dft_r2c_2d(Nny,Nnx,input,output,FFTW_ESTIMATE);
-
-  for(int i=0;i<Nnx*Nny;i++) input[i] = dNmap[i];
-  fftw_execute( p );
-  for(int i=0; i<Nny*(Nnx/2+1);i++){
-    fNmap[i][0] = output[i][0];
-    fNmap[i][1] = output[i][1];
-  }
-  delete[] input;
-  delete[] output;
-  delete[] dNmap;
-  fftw_destroy_plan(p);
-  
-  // fourier space
-  // std:: cout << " allocating fourier space maps " << std:: endl;
-  
-  
-  fftw_complex *fphi   = new fftw_complex[Nny*(Nnx/2+1)];
-  // build modes for each pixel in the fourier space
-  for( int i=0; i<Nnx/2+1; i++ ){
-    double kx=double(i);
-    kx=kx*2.*M_PI/Nboxlx;
-    for( int j=0; j<Nny; j++ ){
-      double ky=(j<Nny/2)?double(j):double(j-Nny);
-      ky=ky*2.*M_PI/Nboxly;
-      double k2 = kx*kx+ky*ky;
-      //smooth if you want to IMPLEMENT
-      // if(npix_filter>0){
-      // fNmap[j+(Nnpixels/2+1)*i][0] = fNmap[j+(Nnpixels/2+1)*i][0]*exp(-k2/sigmag/sigmag/2.);
-      // fNmap[j+(Nnpixels/2+1)*i][1] = fNmap[j+(Nnpixels/2+1)*i][1]*exp(-k2/sigmag/sigmag/2.);
-      // }
       
-      // fphi
-      fphi[i+(Nnx/2+1)*j][0]= -2.*fNmap[i+(Nnx/2+1)*j][0]/k2;
-      fphi[i+(Nnx/2+1)*j][1]= -2.*fNmap[i+(Nnx/2+1)*j][1]/k2;
-      // null for k2 = 0 no divergence
-      if(k2 == 0){
-        fphi[i+(Nnx/2+1)*j][0] = 0.;
-        fphi[i+(Nnx/2+1)*j][1] = 0.;
-      }
-    }
-  }
-  
-  delete[] fNmap;
-  
-  
-  fftw_complex *fft= new fftw_complex[Nny*(Nnx/2+1)];
-  double *realsp = new double[Nnx*Nny];
-  //fftw_plan pp = fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
-  fftw_plan pp = fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_MEASURE);
-  
-  // alpha1
-  {
-    
-    // build modes for each pixel in the fourier space
-    for( int i=0; i<Nnx/2+1; i++ ){
-      double kx=double(i);
-      kx=kx*2.*M_PI/Nboxlx;
-      for( int j=0; j<Nny; j++ ){
-        double ky=(j<Nny/2)?double(j):double(j-Nny);
-        ky=ky*2.*M_PI/Nboxly;
-        
-        fft[i+(Nnx/2+1)*j][0] = -kx*fphi[i+(Nnx/2+1)*j][1];
-        fft[i+(Nnx/2+1)*j][1] =  kx*fphi[i+(Nnx/2+1)*j][0];
-      }
+      //pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
+      fftw_execute( pp );
+      //fftw_destroy_plan(pp);
+      
+      map->alpha1.resize(map->nx*map->ny);
+      
+      for( int i=Nnx/2-map->nx/2; i<Nnx/2+map->nx/2; i++ )
+        for( int j=Nny/2-map->ny/2; j<Nny/2+map->ny/2; j++ ){
+          int ii = i-int(Nnx/2-map->nx/2);
+          int jj = j-int(Nny/2-map->ny/2);
+          
+          map->alpha1[ii+map->nx*jj] = float(realsp[i+Nnx*j]/Nnx/Nny);
+        }
     }
     
-    //pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
-    fftw_execute( pp );
-    //fftw_destroy_plan(pp);
-    
-    map->alpha1.resize(map->nx*map->ny);
-    
-    for( int i=Nnx/2-map->nx/2; i<Nnx/2+map->nx/2; i++ )
-      for( int j=Nny/2-map->ny/2; j<Nny/2+map->ny/2; j++ ){
-        int ii = i-int(Nnx/2-map->nx/2);
-        int jj = j-int(Nny/2-map->ny/2);
-        
-        map->alpha1[ii+map->nx*jj] = float(realsp[i+Nnx*j]/Nnx/Nny);
+    // alpha2
+    {
+      
+      // build modes for each pixel in the fourier space
+      for( int i=0; i<Nnx/2+1; i++ ){
+        double kx=double(i);
+        kx=kx*2.*M_PI/Nboxlx;
+        for( int j=0; j<Nny; j++ ){
+          double ky=(j<Nny/2)?double(j):double(j-Nny);
+          ky=ky*2.*M_PI/Nboxly;
+          
+          // alpha
+          fft[i+(Nnx/2+1)*j][0] = -ky*fphi[i+(Nnx/2+1)*j][1];
+          fft[i+(Nnx/2+1)*j][1] =  ky*fphi[i+(Nnx/2+1)*j][0];
+          
+        }
       }
-  }
-  
-  // alpha2
-  {
-    
-    // build modes for each pixel in the fourier space
-    for( int i=0; i<Nnx/2+1; i++ ){
-      double kx=double(i);
-      kx=kx*2.*M_PI/Nboxlx;
-      for( int j=0; j<Nny; j++ ){
-        double ky=(j<Nny/2)?double(j):double(j-Nny);
-        ky=ky*2.*M_PI/Nboxly;
-        
-        // alpha
-        fft[i+(Nnx/2+1)*j][0] = -ky*fphi[i+(Nnx/2+1)*j][1];
-        fft[i+(Nnx/2+1)*j][1] =  ky*fphi[i+(Nnx/2+1)*j][0];
-        
-      }
-    }
-    
-    //pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
-    fftw_execute( pp );
-    //fftw_destroy_plan(pp);
-    
-    map->alpha2.resize(map->nx*map->ny);
-    
-    for( int i=Nnx/2-map->nx/2; i<Nnx/2+map->nx/2; i++ ){
-      for( int j=Nny/2-map->ny/2; j<Nny/2+map->ny/2; j++ ){
-        int ii = i-int(Nnx/2-map->nx/2);
-        int jj = j-int(Nny/2-map->ny/2);
-        
-        map->alpha2[ii+map->nx*jj] = float(realsp[i+Nnx*j]/Nnx/Nny);
+      
+      //pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
+      fftw_execute( pp );
+      //fftw_destroy_plan(pp);
+      
+      map->alpha2.resize(map->nx*map->ny);
+      
+      for( int i=Nnx/2-map->nx/2; i<Nnx/2+map->nx/2; i++ ){
+        for( int j=Nny/2-map->ny/2; j<Nny/2+map->ny/2; j++ ){
+          int ii = i-int(Nnx/2-map->nx/2);
+          int jj = j-int(Nny/2-map->ny/2);
+          
+          map->alpha2[ii+map->nx*jj] = float(realsp[i+Nnx*j]/Nnx/Nny);
+        }
       }
     }
-  }
-  // gamma1
-  {
-    
-    // build modes for each pixel in the fourier space
-    for( int i=0; i<Nnx/2+1; i++ ){
-      double kx=double(i);
-      kx=kx*2.*M_PI/Nboxlx;
-      for( int j=0; j<Nny; j++ ){
-        double ky=(j<Nny/2)?double(j):double(j-Nny);
-        ky=ky*2.*M_PI/Nboxly;
-        
-        // gamma
-        fft[i+(Nnx/2+1)*j][0] = 0.5*(kx*kx-ky*ky)*fphi[i+(Nnx/2+1)*j][0];
-        fft[i+(Nnx/2+1)*j][1] = 0.5*(kx*kx-ky*ky)*fphi[i+(Nnx/2+1)*j][1];
-                
+    // gamma1
+    {
+      
+      // build modes for each pixel in the fourier space
+      for( int i=0; i<Nnx/2+1; i++ ){
+        double kx=double(i);
+        kx=kx*2.*M_PI/Nboxlx;
+        for( int j=0; j<Nny; j++ ){
+          double ky=(j<Nny/2)?double(j):double(j-Nny);
+          ky=ky*2.*M_PI/Nboxly;
+          
+          // gamma
+          fft[i+(Nnx/2+1)*j][0] = 0.5*(kx*kx-ky*ky)*fphi[i+(Nnx/2+1)*j][0];
+          fft[i+(Nnx/2+1)*j][1] = 0.5*(kx*kx-ky*ky)*fphi[i+(Nnx/2+1)*j][1];
+          
+        }
+      }
+      
+      //pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
+      fftw_execute( pp );
+      //fftw_destroy_plan(pp);
+      
+      map->gamma1.resize(map->nx*map->ny);
+      
+      for( int i=Nnx/2-map->nx/2; i<Nnx/2+map->nx/2; i++ ){
+        for( int j=Nny/2-map->ny/2; j<Nny/2+map->ny/2; j++ ){
+          int ii = i-int(Nnx/2-map->nx/2);
+          int jj = j-int(Nny/2-map->ny/2);
+          
+          map->gamma1[ii+map->nx*jj] = float( realsp[i+Nnx*j]/Nnx/Nny);
+          
+        }
       }
     }
-    
-    //pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
-    fftw_execute( pp );
-    //fftw_destroy_plan(pp);
-    
-    map->gamma1.resize(map->nx*map->ny);
-    
-    for( int i=Nnx/2-map->nx/2; i<Nnx/2+map->nx/2; i++ ){
-      for( int j=Nny/2-map->ny/2; j<Nny/2+map->ny/2; j++ ){
-        int ii = i-int(Nnx/2-map->nx/2);
-        int jj = j-int(Nny/2-map->ny/2);
-        
-        map->gamma1[ii+map->nx*jj] = float( realsp[i+Nnx*j]/Nnx/Nny);
-        
+    // gamma2
+    {
+      
+      // build modes for each pixel in the fourier space
+      for( int i=0; i<Nnx/2+1; i++ ){
+        double kx=double(i);
+        kx=kx*2.*M_PI/Nboxlx;
+        for( int j=0; j<Nny; j++ ){
+          double ky=(j<Nny/2)?double(j):double(j-Nny);
+          ky=ky*2.*M_PI/Nboxly;
+          
+          // gamma
+          fft[i+(Nnx/2+1)*j][0] = kx*ky*fphi[i+(Nnx/2+1)*j][0];
+          fft[i+(Nnx/2+1)*j][1] = kx*ky*fphi[i+(Nnx/2+1)*j][1];
+          
+        }
       }
-    }
-  }
-  // gamma2
-  {
-    
-    // build modes for each pixel in the fourier space
-    for( int i=0; i<Nnx/2+1; i++ ){
-      double kx=double(i);
-      kx=kx*2.*M_PI/Nboxlx;
-      for( int j=0; j<Nny; j++ ){
-        double ky=(j<Nny/2)?double(j):double(j-Nny);
-        ky=ky*2.*M_PI/Nboxly;
-        
-        // gamma
-        fft[i+(Nnx/2+1)*j][0] = kx*ky*fphi[i+(Nnx/2+1)*j][0];
-        fft[i+(Nnx/2+1)*j][1] = kx*ky*fphi[i+(Nnx/2+1)*j][1];
-        
+      
+      //pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
+      fftw_execute( pp );
+      //fftw_destroy_plan(pp);
+      
+      map->gamma2.resize(map->nx*map->ny);
+      
+      for( int i=Nnx/2-map->nx/2; i<Nnx/2+map->nx/2; i++ ){
+        for( int j=Nny/2-map->ny/2; j<Nny/2+map->ny/2; j++ ){
+          int ii = i-int(Nnx/2-map->nx/2);
+          int jj = j-int(Nny/2-map->ny/2);
+          
+          map->gamma2[ii+map->nx*jj] = float(-realsp[i+Nnx*j]/Nnx/Nny);
+          
+        }
       }
     }
     
-    //pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fft,realsp,FFTW_ESTIMATE);
-    fftw_execute( pp );
-    //fftw_destroy_plan(pp);
+    /*
+     double *phi    = new double[Nnx*Nny];
+     fftw_plan pp;
+     pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fphi,phi,FFTW_ESTIMATE);
+     fftw_execute( pp );
+     fftw_destroy_plan(pp);
+     delete[] phi;
+     */
     
-    map->gamma2.resize(map->nx*map->ny);
-    
-    for( int i=Nnx/2-map->nx/2; i<Nnx/2+map->nx/2; i++ ){
-      for( int j=Nny/2-map->ny/2; j<Nny/2+map->ny/2; j++ ){
-        int ii = i-int(Nnx/2-map->nx/2);
-        int jj = j-int(Nny/2-map->ny/2);
-        
-        map->gamma2[ii+map->nx*jj] = float(-realsp[i+Nnx*j]/Nnx/Nny);
-        
-      }
-    }
-  }
-  
-  /*
-  double *phi    = new double[Nnx*Nny];
-  fftw_plan pp;
-  pp=fftw_plan_dft_c2r_2d(Nny,Nnx,fphi,phi,FFTW_ESTIMATE);
-  fftw_execute( pp );
-  fftw_destroy_plan(pp);
-  delete[] phi;
-  */
-  
-  // std:: cout << " remapping the map in the original size " << std:: endl;
-  delete[] fft;
-  delete[] realsp;
-  delete[] fphi;
+    // std:: cout << " remapping the map in the original size " << std:: endl;
+    delete[] fft;
+    delete[] realsp;
+    delete[] fphi;
 #endif
-}
-
-
+  }
+  
+  

--- a/MultiPlane/MOKAlens.cpp
+++ b/MultiPlane/MOKAlens.cpp
@@ -13,7 +13,7 @@ using namespace std;
 /*
  * \brief center of mass of a map using the moving centre
  */
-void cmass(int n, std::valarray<double> map, std:: vector<double> x, double &xcm, double &ycm){ 
+void cmass(int n, std::valarray<double> map, std:: vector<double> x, double &xcm, double &ycm){
   double shrink = 1.02;
   // 0.05% of the total number of pixels
   int nstop = int(0.05*double(n)*double(n)/100.);
@@ -25,7 +25,7 @@ void cmass(int n, std::valarray<double> map, std:: vector<double> x, double &xcm
   //
   double rsel = x[n-1] - x[0];
   double xmin = x[0];
-  double drpix = rsel/n;  
+  double drpix = rsel/n;
   rsel/=2.;
   // I will set in the centre with t width equal to 128 pixels
   rsel = drpix*64.;
@@ -40,16 +40,16 @@ void cmass(int n, std::valarray<double> map, std:: vector<double> x, double &xcm
     tot = 0;
     nsel = 0;
     for(i=0;i<n;i++) for(j=0;j<n;j++){
-	xi = (xmin+(drpix*0.5)+i*drpix);
-	yi = (xmin+(drpix*0.5)+j*drpix);
-	dist = sqrt(pow(xi-xcm,2)+ pow(yi-ycm,2));
-	if(dist<=rsel){
-	  nxcm+=map[i+n*j]*xi;
-	  nycm+=map[i+n*j]*yi;
-	  tot+=map[i+n*j];
-	  nsel++;
-	}
+      xi = (xmin+(drpix*0.5)+i*drpix);
+      yi = (xmin+(drpix*0.5)+j*drpix);
+      dist = sqrt(pow(xi-xcm,2)+ pow(yi-ycm,2));
+      if(dist<=rsel){
+        nxcm+=map[i+n*j]*xi;
+        nycm+=map[i+n*j]*yi;
+        tot+=map[i+n*j];
+        nsel++;
       }
+    }
     nxcm/=tot;
     nycm/=tot;
     rsel = rsel / shrink;
@@ -63,15 +63,15 @@ void cmass(int n, std::valarray<double> map, std:: vector<double> x, double &xcm
  * \brief loads a MOKA map from a given filename
  */
 
-LensHaloMassMap::LensHaloMassMap(const std::string& filename, PixelMapType my_maptype,int pixel_map_zeropad, const COSMOLOGY& lenscosmo)
+LensHaloMassMap::LensHaloMassMap(const std::string& filename, PixelMapType my_maptype,int pixel_map_zeropad,bool my_zeromean, const COSMOLOGY& lenscosmo)
 : LensHalo(),
-  MOKA_input_file(filename), flag_MOKA_analyze(0), flag_background_field(0),
-  maptype(my_maptype), cosmo(lenscosmo),zerosize(pixel_map_zeropad)
+MOKA_input_file(filename), flag_MOKA_analyze(0), flag_background_field(0),
+maptype(my_maptype), cosmo(lenscosmo),zerosize(pixel_map_zeropad),zeromean(my_zeromean)
 {
-	initMap();
+  initMap();
  	
-	// set redshift to value from map
-	setZlens(map->zlens);
+  // set redshift to value from map
+  setZlens(map->zlens);
 }
 
 /**
@@ -82,20 +82,20 @@ LensHaloMassMap::LensHaloMassMap(const std::string& filename, PixelMapType my_ma
 LensHaloMassMap::LensHaloMassMap(InputParams& params, const COSMOLOGY& lenscosmo)
 : LensHalo(), maptype(moka), cosmo(lenscosmo)
 {
-	// read in parameters
-	assignParams(params);
-	
-	// initialize MOKA map
-	initMap();
-	
-	// set redshift if necessary
-	if(zlens == -1)
-		setZlens(map->zlens);
+  // read in parameters
+  assignParams(params);
+  
+  // initialize MOKA map
+  initMap();
+  
+  // set redshift if necessary
+  if(zlens == -1)
+    setZlens(map->zlens);
 }
 
 LensHaloMassMap::~LensHaloMassMap()
 {
-	delete map;
+  delete map;
 }
 
 void LensHaloMassMap::initMap()
@@ -105,79 +105,79 @@ void LensHaloMassMap::initMap()
     ERROR_MESSAGE();
     throw runtime_error("Does not recognize input lens map type");
   }
-
-#ifndef ENABLE_FITS
-	std::cout << "Please enable the preprocessor flag ENABLE_FITS !" << std::endl;
-	exit(1);
-#endif
-
-	map = new MOKAmap();
   
-	if(std::numeric_limits<float>::has_infinity)
-		Rmax = std::numeric_limits<float>::infinity();
-	else
-		Rmax = std::numeric_limits<float>::max();
-	
-	getDims();
-	
-	std::size_t size = map->nx*map->ny;
-	
-	map->convergence.resize(size);
-	map->alpha1.resize(size);
-	map->alpha2.resize(size);
-	map->gamma1.resize(size);
-	map->gamma2.resize(size); 
-	map->gamma3.resize(size);
-	map->phi.resize(size);
-	
-	readMap();
-
-	if(flag_background_field == 1)
-	{
-		map->convergence = 0;
-		map->alpha1 = 0;
-		map->alpha2 = 0;
-		map->gamma1 = 0;
-		map->gamma2 = 0;
-		map->phi = 0;
-	}
-
-    map->center[0] = map->center[1] = 0.0;
-    map->boxlrad = map->boxlarcsec*pi/180/3600.;
-    map->inarcsec  = 10800./M_PI/map->Dlens*60.; // Mpc/h to arcsec for MOKA while Mpc to arcsec for Pixeliz
-
-    if(maptype == moka){
-      
-        Utilities::fill_linear(map->x, map->nx, -0.5*map->boxlMpc, 0.5*map->boxlMpc); // physical Mpc/h
-      
-        /// converts to the code units
-        std::cout << "converting the units of the MOKA map" << std::endl;
-
-        double fac = map->DS/map->DLS/map->Dlens*map->h/(4*pi*Grav);
-		
-        map->convergence *= fac;
-        map->gamma1 *= fac;
-        map->gamma2 *= fac;
-        map->phi *= fac;
-      
-        fac = 1/(4*pi*Grav);
-		
-        map->alpha1 *= fac;
-        map->alpha2 *= fac;
-      
-        checkCosmology();
-    }else{
-        // simulation case
-        // not needed for now does all in MOKAfits.cpp
-        // convertmap(map,maptype);
+#ifndef ENABLE_FITS
+  std::cout << "Please enable the preprocessor flag ENABLE_FITS !" << std::endl;
+  exit(1);
+#endif
+  
+  map = new MOKAmap();
+  
+  if(std::numeric_limits<float>::has_infinity)
+    Rmax = std::numeric_limits<float>::infinity();
+  else
+    Rmax = std::numeric_limits<float>::max();
+  
+  getDims();
+  
+  std::size_t size = map->nx*map->ny;
+  
+  map->convergence.resize(size);
+  map->alpha1.resize(size);
+  map->alpha2.resize(size);
+  map->gamma1.resize(size);
+  map->gamma2.resize(size);
+  map->gamma3.resize(size);
+  map->phi.resize(size);
+  
+  readMap();
+  
+  if(flag_background_field == 1)
+  {
+    map->convergence = 0;
+    map->alpha1 = 0;
+    map->alpha2 = 0;
+    map->gamma1 = 0;
+    map->gamma2 = 0;
+    map->phi = 0;
+  }
+  
+  map->center[0] = map->center[1] = 0.0;
+  map->boxlrad = map->boxlarcsec*pi/180/3600.;
+  map->inarcsec  = 10800./M_PI/map->Dlens*60.; // Mpc/h to arcsec for MOKA while Mpc to arcsec for Pixeliz
+  
+  if(maptype == moka){
+    
+    Utilities::fill_linear(map->x, map->nx, -0.5*map->boxlMpc, 0.5*map->boxlMpc); // physical Mpc/h
+    
+    /// converts to the code units
+    std::cout << "converting the units of the MOKA map" << std::endl;
+    
+    double fac = map->DS/map->DLS/map->Dlens*map->h/(4*pi*Grav);
+    
+    map->convergence *= fac;
+    map->gamma1 *= fac;
+    map->gamma2 *= fac;
+    map->phi *= fac;
+    
+    fac = 1/(4*pi*Grav);
+    
+    map->alpha1 *= fac;
+    map->alpha2 *= fac;
+    
+    checkCosmology();
+  }else{
+    // simulation case
+    // not needed for now does all in MOKAfits.cpp
+    // convertmap(map,maptype);
   }
 }
 
 void LensHaloMassMap::convertmap(MOKAmap *map,PixelMapType maptype){
-
+  
   // TODO: convert units
   throw std::runtime_error("needs to be finished");
-
+  
   map->center[0] *= map->Dlens;//(1+map->zlens);
   map->center[1] *= map->Dlens;//(1+map->zlens);
   
@@ -187,7 +187,7 @@ void LensHaloMassMap::convertmap(MOKAmap *map,PixelMapType maptype){
   //map->convergence *= fac;
   //map->gamma1 *= fac;
   //map->gamma2 *= fac;
-
+  
   // TODO: Need to check this
   //map->alpha1 *= fac*pixLMpc;
   //map->alpha2 *= fac*pixLMpc;
@@ -199,12 +199,12 @@ void LensHaloMassMap::convertmap(MOKAmap *map,PixelMapType maptype){
 /// checks that cosmology in the header of the input fits map is the same as the one set
 void LensHaloMassMap::checkCosmology()
 {
-	if(cosmo.getOmega_matter() == map->omegam)
-		std::cerr << "LensHaloMassMap: Omega_matter " << cosmo.getOmega_matter() << " (cosmology) != " << map->omegam << " (MOKA)" << std::endl;
-	if(cosmo.getOmega_lambda() == map->omegal)
-		std::cerr << "LensHaloMassMap: Omega_lambda " << cosmo.getOmega_lambda() << " (cosmology) != " << map->omegal << " (MOKA)" << std::endl;
-	if(cosmo.gethubble() == map->h)
-		std::cerr << "LensHaloMassMap: hubble " << cosmo.gethubble() << " (cosmology) != " << map->h << " (MOKA)" << std::endl;
+  if(cosmo.getOmega_matter() == map->omegam)
+    std::cerr << "LensHaloMassMap: Omega_matter " << cosmo.getOmega_matter() << " (cosmology) != " << map->omegam << " (MOKA)" << std::endl;
+  if(cosmo.getOmega_lambda() == map->omegal)
+    std::cerr << "LensHaloMassMap: Omega_lambda " << cosmo.getOmega_lambda() << " (cosmology) != " << map->omegal << " (MOKA)" << std::endl;
+  if(cosmo.gethubble() == map->h)
+    std::cerr << "LensHaloMassMap: hubble " << cosmo.gethubble() << " (cosmology) != " << map->h << " (MOKA)" << std::endl;
 }
 
 /**
@@ -213,22 +213,23 @@ void LensHaloMassMap::checkCosmology()
 
 void LensHaloMassMap::assignParams(InputParams& params)
 {
-	if(!params.get("z_lens", zlens))
-		zlens = -1; // set to -1 so that it will be set to the MOKA map value
-	
-	if(!params.get("MOKA_input_file", MOKA_input_file))
-	{
-		ERROR_MESSAGE();
-		std::cout << "parameter MOKA_input_file needs to be set in parameter file " << params.filename() << std::endl;
-		exit(0);
-	}
-	
-	if(!params.get("MOKA_background_field", flag_background_field))
-		flag_background_field = 0;
-	
-	if(!params.get("MOKA_analyze",flag_MOKA_analyze))
-		flag_MOKA_analyze = 0;
+  if(!params.get("z_lens", zlens))
+    zlens = -1; // set to -1 so that it will be set to the MOKA map value
   
+  if(!params.get("MOKA_input_file", MOKA_input_file))
+  {
+    ERROR_MESSAGE();
+    std::cout << "parameter MOKA_input_file needs to be set in parameter file " << params.filename() << std::endl;
+    exit(0);
+  }
+  
+  if(!params.get("MOKA_background_field", flag_background_field))
+    flag_background_field = 0;
+  
+  if(!params.get("MOKA_analyze",flag_MOKA_analyze))
+    flag_MOKA_analyze = 0;
+  
+  zeromean = true;
   zerosize = 4;  /// not really used
   maptype = moka;
 }
@@ -239,51 +240,51 @@ void LensHaloMassMap::assignParams(InputParams& params)
  * of the convergence
  */
 void LensHaloMassMap::saveImage(GridHndl grid,bool saveprofiles){
-	std::stringstream f;
-	std::string filename;
-
-	if(flag_background_field==1) f << MOKA_input_file << "_only_noise.fits";
-	else{
-	  if(flag_MOKA_analyze == 0) f << MOKA_input_file << "_noisy.fits";
-	  else f << MOKA_input_file << "_no_noise.fits";
-	}
-	filename = f.str();
-
+  std::stringstream f;
+  std::string filename;
+  
+  if(flag_background_field==1) f << MOKA_input_file << "_only_noise.fits";
+  else{
+    if(flag_MOKA_analyze == 0) f << MOKA_input_file << "_noisy.fits";
+    else f << MOKA_input_file << "_no_noise.fits";
+  }
+  filename = f.str();
+  
   PointList::iterator i_tree_pointlist_current(grid->i_tree->pointlist->Top());
-
-	do{
-		long index = Utilities::IndexFromPosition((*i_tree_pointlist_current)->x,map->nx,map->boxlrad,map->center);
-		if(index > -1){
-			map->convergence[index] = (*i_tree_pointlist_current)->kappa;
-			map->gamma1[index] = (*i_tree_pointlist_current)->gamma[0];
-			map->gamma2[index] = (*i_tree_pointlist_current)->gamma[1];
-			map->gamma3[index] = (*i_tree_pointlist_current)->gamma[2];
-		}
-	}while( (--i_tree_pointlist_current)==true );
-
-	writeImage(filename);
-
-	if(saveprofiles == true){
-
-	  std:: cout << " saving profile " << std:: endl;
-	  double RE3,xxc,yyc;
-	  saveProfiles(RE3,xxc,yyc);
-	  estSignLambdas();
-	  double RE1,RE2;
-	  EinsteinRadii(RE1,RE2,xxc,yyc);
-	  std::ostringstream fEinr;
-	  if(flag_background_field==1) fEinr << MOKA_input_file << "_only_noise_Einstein.radii.dat";
-	  else{
-	    if(flag_MOKA_analyze == 0) fEinr << MOKA_input_file << "_noisy_Einstein.radii.dat";
-	    else fEinr << MOKA_input_file << "_no_noise_Einstein.radii.dat";
-	  }
-	  std:: ofstream filoutEinr;
-	  std:: string filenameEinr = fEinr.str();
-	  filoutEinr.open(filenameEinr.c_str());
-	  filoutEinr << "# effective        median      from_profiles" << std:: endl;
-	  filoutEinr << RE1 << "   " << RE2 << "    " << RE3 << std:: endl;
-	  filoutEinr.close();
-	}
+  
+  do{
+    long index = Utilities::IndexFromPosition((*i_tree_pointlist_current)->x,map->nx,map->boxlrad,map->center);
+    if(index > -1){
+      map->convergence[index] = (*i_tree_pointlist_current)->kappa;
+      map->gamma1[index] = (*i_tree_pointlist_current)->gamma[0];
+      map->gamma2[index] = (*i_tree_pointlist_current)->gamma[1];
+      map->gamma3[index] = (*i_tree_pointlist_current)->gamma[2];
+    }
+  }while( (--i_tree_pointlist_current)==true );
+  
+  writeImage(filename);
+  
+  if(saveprofiles == true){
+    
+    std:: cout << " saving profile " << std:: endl;
+    double RE3,xxc,yyc;
+    saveProfiles(RE3,xxc,yyc);
+    estSignLambdas();
+    double RE1,RE2;
+    EinsteinRadii(RE1,RE2,xxc,yyc);
+    std::ostringstream fEinr;
+    if(flag_background_field==1) fEinr << MOKA_input_file << "_only_noise_Einstein.radii.dat";
+    else{
+      if(flag_MOKA_analyze == 0) fEinr << MOKA_input_file << "_noisy_Einstein.radii.dat";
+      else fEinr << MOKA_input_file << "_no_noise_Einstein.radii.dat";
+    }
+    std:: ofstream filoutEinr;
+    std:: string filenameEinr = fEinr.str();
+    filoutEinr.open(filenameEinr.c_str());
+    filoutEinr << "# effective        median      from_profiles" << std:: endl;
+    filoutEinr << RE1 << "   " << RE2 << "    " << RE3 << std:: endl;
+    filoutEinr.close();
+  }
 }
 
 
@@ -291,196 +292,196 @@ void LensHaloMassMap::saveImage(GridHndl grid,bool saveprofiles){
  * computing and saving the radial profile of the convergence, reduced tangential and parallel shear and of the shear
  *  */
 void LensHaloMassMap::saveProfiles(double &RE3,double &xxc,double &yyc){
-	/* measuring the differential and cumulative profile*/
-	double xmin = -map->boxlMpc*0.5;
-	double xmax =  map->boxlMpc*0.5;
-	double drpix = map->boxlMpc/map->nx;
-
-	int galaxiesPerBin = 64;
-
-	std::valarray<double> pxdist(map->nx*map->ny);
-	std::valarray<double> red_sgE(map->nx*map->ny),red_sgB(map->nx*map->ny),sgm(map->nx*map->ny); 
-	int i, j;
-	/*
+  /* measuring the differential and cumulative profile*/
+  double xmin = -map->boxlMpc*0.5;
+  double xmax =  map->boxlMpc*0.5;
+  double drpix = map->boxlMpc/map->nx;
+  
+  int galaxiesPerBin = 64;
+  
+  std::valarray<double> pxdist(map->nx*map->ny);
+  std::valarray<double> red_sgE(map->nx*map->ny),red_sgB(map->nx*map->ny),sgm(map->nx*map->ny);
+  int i, j;
+  /*
 	  measure the center of mass
 	  double xcm=0,ycm=0,tot=0;
 	  for(i=0; i<map->nx; i++ ) for(j=0; j<map->ny; j++ ){
 	  xcm+=map->convergence[i+map->ny*j]*(xmin+(drpix*0.5)+i*drpix);
 	  ycm+=map->convergence[i+map->ny*j]*(xmin+(drpix*0.5)+j*drpix);
 	  tot+=map->convergence[i+map->ny*j];
-	  }	
+	  }
 	  xcm/=tot;
 	  ycm/=tot;
 	  xxc = xcm;
 	  yyc = ycm;
-	*/
-	// moving center
-        double xcm,ycm;
-	if(flag_background_field==1){
-	  xcm = 0.;
-	  ycm = 0.;
-	}
-	else{
-	  cmass(map->ny,map->convergence,map->x,xcm,ycm);
-	}
-	xxc = xcm;
-	yyc = ycm;
-	int ai = Utilities::locate(map->x,xxc);
-	ai = ((ai > 0) ? ai:0);
-	ai = ((ai < map->nx-1) ? ai:map->nx-1);
-	int bi = Utilities::locate(map->x,yyc);
-	bi = ((bi > 0) ? bi:0);
-	bi = ((bi < map->nx-1) ? bi:map->nx-1);
-	std:: cout << "  ------------ center ------------- " << std:: endl;
-	std:: cout << "    " << xxc << "  " << yyc << std:: endl;
-	std:: cout << "    " << ai << "  " << bi << std:: endl;
-	std:: cout << "  ------------------r ------------- " << std:: endl;
-	for(i=0; i<map->nx; i++ ) for(j=0; j<map->ny; j++ ){
-	    pxdist[i+map->ny*j]= sqrt(pow((xmin+(drpix*0.5)+i*drpix-xcm),2) +
-				pow((xmin+(drpix*0.5)+j*drpix-ycm),2));
-		// reduced shear E a B
-		double dx=map->x[i];
-		double dy=map->x[j];
-		double p=atan2( dy, dx ); // check gamma 1 and gamma 2 definition
-		red_sgE[i+map->ny*j] = (-map->gamma1[i+map->ny*j]*cos(2*p)-map->gamma2[i+map->ny*j]*sin(2*p))/(1.-map->convergence[i+map->ny*j]);
-		red_sgB[i+map->ny*j] = (map->gamma1[i+map->ny*j]*sin(2*p)-map->gamma2[i+map->ny*j]*cos(2*p))/(1.-map->convergence[i+map->ny*j]);
-		sgm[i+map->ny*j] = sqrt(pow(map->gamma1[i+map->ny*j],2) + pow(map->gamma2[i+map->ny*j],2));
-	}
-
-	double dr0 = 8.*(0.5*map->boxlMpc)/(map->nx/2.);
-	int nbin = int(xmax/dr0);                           
-	int nbggal=0;
-	int ih;
-	// check if backgroundgalXarcmin2.d file exist
-	std:: string filebgXarcmin2 = "backgroundgalXarcmin2.d";
-	std:: ifstream infilebgXarcmin2;
-	infilebgXarcmin2.open(filebgXarcmin2.c_str());
-	// ... if so it read it!
-	if(infilebgXarcmin2.is_open()){
-	  std:: cout << " I will read  backgroundgalXarcmin2.d file" << std:: endl;
-	  infilebgXarcmin2 >> nbggal;
-	  infilebgXarcmin2 >> ih;
-	  std:: cout << "  and consider " << nbggal <<  " per arcmin2 as background points " << std:: endl;
-	  std:: cout << " in building the cluster profile" << std:: endl;
-	  infilebgXarcmin2.close();
-	}    
-    // number of galaxies per arcminsquare
-	double dntbggal=double(nbggal)*(map->boxlarcsec*map->boxlarcsec)/3600.;
-	int ntbggal=int(dntbggal+0.5);
-	std:: vector<int> runi,runj;
-	int ibut;
-	int lrun;
-	if(ntbggal>0){
-	  std:: cout << " ~ ~ ~ " << ntbggal << " number of bg gal in the field" << std:: endl;
-	  // fill the vector with random coordinates of background galaxies
-	  srand(ih+94108);
-	  for(lrun=0;lrun<ntbggal;lrun++){
-	    ibut = rand()%map->nx;
-	    if(ibut>map->nx || ibut<0) std:: cout << "1. ibut out of npix range = " << ibut << std:: endl;
-	    runi.push_back(ibut);
-	    ibut = rand()%map->nx;
-	    if(ibut>map->nx || ibut<0) std:: cout << "2. ibut out of npix range = " << ibut << std:: endl;
-	    runj.push_back(ibut);
-	  }
-	  if(runi.size()>ntbggal || runj.size()>ntbggal){
-	    std:: cout << " random points in the field out of range " << std:: endl;
-	    std:: cout << " runi.size() = " << runi.size() << std:: endl;
-	    std:: cout << " runj.size() = " << runj.size() << std:: endl;	      
-	  }
-
-	  dr0 = map->boxlMpc*sqrt(galaxiesPerBin/ntbggal);
-
-	  nbin = int(xmax/dr0);                                                        
-	}
-	//                                                                                           
-	std:: cout << "   " << std:: endl;                                                           
-	std:: cout << " nbins = " << nbin << "  dr0 = " << dr0 << std:: endl;                        
-	std:: cout << " ______________________________________________________ " << std:: endl;      
-	std:: cout << " computing profiles assuming spherical symmetry";                                
-	// - - - - - - - - - - - - - - - - -
-
-	// TODO: Carlo:  These are all memory leaks!  They are never deleted!
-	double *kprofr = estprof(map->convergence,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal);                                          
-	double *sigmakprof = estsigmaprof(map->convergence,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,kprofr);                          
-	double *ckprofr = estcprof(map->convergence,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal);                                          
-	double *sigmackprof = estsigmacprof(map->convergence,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,kprofr);                          
-	double *gamma1profr = estprof(red_sgE,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal); // reduced shear
-	double *sigmagamma1prof = estsigmaprof(red_sgE,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,gamma1profr);              
-	double *gamma0profr = estprof(red_sgB,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal);  
-	double *sigmagamma0prof = estsigmaprof(red_sgB,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,gamma0profr);              
-	double *gamma2profr = estprof(sgm,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal);  
-	double *sigmagamma2prof = estsigmaprof(sgm,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,gamma2profr);              
-	std::ostringstream fprof;
-
-	if(flag_background_field==1) fprof << MOKA_input_file << "_only_noise_MAP_radial_prof.dat";
-	else{
-	  if(flag_MOKA_analyze == 0) fprof << MOKA_input_file << "_noisy_MAP_radial_prof.dat";
-	  else fprof << MOKA_input_file << "_no_noise_MAP_radial_prof.dat";
-	}
-	std:: ofstream filoutprof;
-	std:: string filenameprof = fprof.str();
-	filoutprof.open(filenameprof.c_str());
-	filoutprof <<"# r      kappa     sig_k     ckappa     sig_ck    redgE   sig_redgE   redgB   sig_redgE   g   sig_g   theta   Anulus_area" << std:: endl;
-	int l;
-	std:: vector<double> lrOFr(nbin),lprofFORre(nbin);
-	for(l=0;l<nbin;l++){
-	  double Aanulus = M_PI*((dr0*l+dr0)*(dr0*l+dr0)-(dr0*l)*(dr0*l)); 
-	  filoutprof << dr0*l + dr0/2. << "  " 
-		     << kprofr[l] << "  " << sigmakprof[l] << "  " 
-		     << ckprofr[l] << "  " << sigmackprof[l] << "   " 
-		     << gamma1profr[l] << "  " << sigmagamma1prof[l] << "  " 
-		     << gamma0profr[l] << "  " << sigmagamma0prof[l] << "  " 
-	    	     << gamma2profr[l] << "  " << sigmagamma2prof[l] << "   "
-		     << (dr0*l + dr0/2.)*map->inarcsec << "   "  << Aanulus*map->inarcsec*map->inarcsec << "   " <<  
-	    std:: endl;
-	  lprofFORre[l] = log10(kprofr[l] + gamma2profr[l]);
-	  lrOFr[l] = log10(dr0*l + dr0/2.);
-	}
-	filoutprof.close();
-	RE3 = Utilities::InterpolateYvec(lprofFORre,lrOFr,0.);  
-	if((RE3-lrOFr[0])<1e-4 || (RE3-lrOFr[nbin-1])<1e-4) RE3=0;
-	else RE3 = pow(10.,RE3)*map->inarcsec;
+   */
+  // moving center
+  double xcm,ycm;
+  if(flag_background_field==1){
+    xcm = 0.;
+    ycm = 0.;
+  }
+  else{
+    cmass(map->ny,map->convergence,map->x,xcm,ycm);
+  }
+  xxc = xcm;
+  yyc = ycm;
+  int ai = Utilities::locate(map->x,xxc);
+  ai = ((ai > 0) ? ai:0);
+  ai = ((ai < map->nx-1) ? ai:map->nx-1);
+  int bi = Utilities::locate(map->x,yyc);
+  bi = ((bi > 0) ? bi:0);
+  bi = ((bi < map->nx-1) ? bi:map->nx-1);
+  std:: cout << "  ------------ center ------------- " << std:: endl;
+  std:: cout << "    " << xxc << "  " << yyc << std:: endl;
+  std:: cout << "    " << ai << "  " << bi << std:: endl;
+  std:: cout << "  ------------------r ------------- " << std:: endl;
+  for(i=0; i<map->nx; i++ ) for(j=0; j<map->ny; j++ ){
+    pxdist[i+map->ny*j]= sqrt(pow((xmin+(drpix*0.5)+i*drpix-xcm),2) +
+                              pow((xmin+(drpix*0.5)+j*drpix-ycm),2));
+    // reduced shear E a B
+    double dx=map->x[i];
+    double dy=map->x[j];
+    double p=atan2( dy, dx ); // check gamma 1 and gamma 2 definition
+    red_sgE[i+map->ny*j] = (-map->gamma1[i+map->ny*j]*cos(2*p)-map->gamma2[i+map->ny*j]*sin(2*p))/(1.-map->convergence[i+map->ny*j]);
+    red_sgB[i+map->ny*j] = (map->gamma1[i+map->ny*j]*sin(2*p)-map->gamma2[i+map->ny*j]*cos(2*p))/(1.-map->convergence[i+map->ny*j]);
+    sgm[i+map->ny*j] = sqrt(pow(map->gamma1[i+map->ny*j],2) + pow(map->gamma2[i+map->ny*j],2));
+  }
+  
+  double dr0 = 8.*(0.5*map->boxlMpc)/(map->nx/2.);
+  int nbin = int(xmax/dr0);
+  int nbggal=0;
+  int ih;
+  // check if backgroundgalXarcmin2.d file exist
+  std:: string filebgXarcmin2 = "backgroundgalXarcmin2.d";
+  std:: ifstream infilebgXarcmin2;
+  infilebgXarcmin2.open(filebgXarcmin2.c_str());
+  // ... if so it read it!
+  if(infilebgXarcmin2.is_open()){
+    std:: cout << " I will read  backgroundgalXarcmin2.d file" << std:: endl;
+    infilebgXarcmin2 >> nbggal;
+    infilebgXarcmin2 >> ih;
+    std:: cout << "  and consider " << nbggal <<  " per arcmin2 as background points " << std:: endl;
+    std:: cout << " in building the cluster profile" << std:: endl;
+    infilebgXarcmin2.close();
+  }
+  // number of galaxies per arcminsquare
+  double dntbggal=double(nbggal)*(map->boxlarcsec*map->boxlarcsec)/3600.;
+  int ntbggal=int(dntbggal+0.5);
+  std:: vector<int> runi,runj;
+  int ibut;
+  int lrun;
+  if(ntbggal>0){
+    std:: cout << " ~ ~ ~ " << ntbggal << " number of bg gal in the field" << std:: endl;
+    // fill the vector with random coordinates of background galaxies
+    srand(ih+94108);
+    for(lrun=0;lrun<ntbggal;lrun++){
+      ibut = rand()%map->nx;
+      if(ibut>map->nx || ibut<0) std:: cout << "1. ibut out of npix range = " << ibut << std:: endl;
+      runi.push_back(ibut);
+      ibut = rand()%map->nx;
+      if(ibut>map->nx || ibut<0) std:: cout << "2. ibut out of npix range = " << ibut << std:: endl;
+      runj.push_back(ibut);
+    }
+    if(runi.size()>ntbggal || runj.size()>ntbggal){
+      std:: cout << " random points in the field out of range " << std:: endl;
+      std:: cout << " runi.size() = " << runi.size() << std:: endl;
+      std:: cout << " runj.size() = " << runj.size() << std:: endl;
+    }
+    
+    dr0 = map->boxlMpc*sqrt(galaxiesPerBin/ntbggal);
+    
+    nbin = int(xmax/dr0);
+  }
+  //
+  std:: cout << "   " << std:: endl;
+  std:: cout << " nbins = " << nbin << "  dr0 = " << dr0 << std:: endl;
+  std:: cout << " ______________________________________________________ " << std:: endl;
+  std:: cout << " computing profiles assuming spherical symmetry";
+  // - - - - - - - - - - - - - - - - -
+  
+  // TODO: Carlo:  These are all memory leaks!  They are never deleted!
+  double *kprofr = estprof(map->convergence,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal);
+  double *sigmakprof = estsigmaprof(map->convergence,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,kprofr);
+  double *ckprofr = estcprof(map->convergence,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal);
+  double *sigmackprof = estsigmacprof(map->convergence,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,kprofr);
+  double *gamma1profr = estprof(red_sgE,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal); // reduced shear
+  double *sigmagamma1prof = estsigmaprof(red_sgE,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,gamma1profr);
+  double *gamma0profr = estprof(red_sgB,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal);
+  double *sigmagamma0prof = estsigmaprof(red_sgB,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,gamma0profr);
+  double *gamma2profr = estprof(sgm,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal);
+  double *sigmagamma2prof = estsigmaprof(sgm,map->nx,map->ny,pxdist,dr0,xmax,runi,runj,ntbggal,gamma2profr);
+  std::ostringstream fprof;
+  
+  if(flag_background_field==1) fprof << MOKA_input_file << "_only_noise_MAP_radial_prof.dat";
+  else{
+    if(flag_MOKA_analyze == 0) fprof << MOKA_input_file << "_noisy_MAP_radial_prof.dat";
+    else fprof << MOKA_input_file << "_no_noise_MAP_radial_prof.dat";
+  }
+  std:: ofstream filoutprof;
+  std:: string filenameprof = fprof.str();
+  filoutprof.open(filenameprof.c_str());
+  filoutprof <<"# r      kappa     sig_k     ckappa     sig_ck    redgE   sig_redgE   redgB   sig_redgE   g   sig_g   theta   Anulus_area" << std:: endl;
+  int l;
+  std:: vector<double> lrOFr(nbin),lprofFORre(nbin);
+  for(l=0;l<nbin;l++){
+    double Aanulus = M_PI*((dr0*l+dr0)*(dr0*l+dr0)-(dr0*l)*(dr0*l));
+    filoutprof << dr0*l + dr0/2. << "  "
+    << kprofr[l] << "  " << sigmakprof[l] << "  "
+    << ckprofr[l] << "  " << sigmackprof[l] << "   "
+    << gamma1profr[l] << "  " << sigmagamma1prof[l] << "  "
+    << gamma0profr[l] << "  " << sigmagamma0prof[l] << "  "
+    << gamma2profr[l] << "  " << sigmagamma2prof[l] << "   "
+    << (dr0*l + dr0/2.)*map->inarcsec << "   "  << Aanulus*map->inarcsec*map->inarcsec << "   " <<
+    std:: endl;
+    lprofFORre[l] = log10(kprofr[l] + gamma2profr[l]);
+    lrOFr[l] = log10(dr0*l + dr0/2.);
+  }
+  filoutprof.close();
+  RE3 = Utilities::InterpolateYvec(lprofFORre,lrOFr,0.);
+  if((RE3-lrOFr[0])<1e-4 || (RE3-lrOFr[nbin-1])<1e-4) RE3=0;
+  else RE3 = pow(10.,RE3)*map->inarcsec;
 }
 
 /** \ingroup DeflectionL2
-   *
-   * \brief Routine for obtaining the deflection and other lensing quantities for
-   * a MOKA map (MOKALensHalo), for just one ray!!
-   *
-*/
+ *
+ * \brief Routine for obtaining the deflection and other lensing quantities for
+ * a MOKA map (MOKALensHalo), for just one ray!!
+ *
+ */
 void LensHaloMassMap::force_halo(double *alpha
-                              ,KappaType *kappa
-                              ,KappaType *gamma
-                              ,KappaType *phi
-                              ,double const *xx
-                              ,bool subtract_point
-                              ,PosType screening
-                              )
+                                 ,KappaType *kappa
+                                 ,KappaType *gamma
+                                 ,KappaType *phi
+                                 ,double const *xx
+                                 ,bool subtract_point
+                                 ,PosType screening
+                                 )
 {
   
   /*
-  long index = Utilities::IndexFromPosition(xx,map->nx,map->boxlMpc/map->h,map->center);
-
-	if(index > -1){
-		alpha[0] = map->alpha1[index];
-		alpha[1] = map->alpha2[index];
-		gamma[0] = map->gamma1[index];
-		gamma[1] = map->gamma2[index];
-		gamma[2] = 0.0;
-		*kappa = map->convergence[index];
-	}
-	else{
-		alpha[0] = alpha[1] = 0.0;
-		gamma[0] = gamma[1] = gamma[2] = 0.0;
-		*kappa = 0.0;
-	}
+   long index = Utilities::IndexFromPosition(xx,map->nx,map->boxlMpc/map->h,map->center);
+   
+   if(index > -1){
+   alpha[0] = map->alpha1[index];
+   alpha[1] = map->alpha2[index];
+   gamma[0] = map->gamma1[index];
+   gamma[1] = map->gamma2[index];
+   gamma[2] = 0.0;
+   *kappa = map->convergence[index];
+   }
+   else{
+   alpha[0] = alpha[1] = 0.0;
+   gamma[0] = gamma[1] = gamma[2] = 0.0;
+   *kappa = 0.0;
+   }
    */
   
   // interpolate from the maps
-
+  
   Utilities::Interpolator<valarray<double> > interp(xx,map->nx,map->boxlMpc,map->ny
                                                     ,map->ny*map->boxlMpc/map->nx,map->center);
-
+  
   alpha[0] = interp.interpolate(map->alpha1);
   alpha[1] = interp.interpolate(map->alpha2);
   gamma[0] = interp.interpolate(map->gamma1);
@@ -488,8 +489,8 @@ void LensHaloMassMap::force_halo(double *alpha
   gamma[2] = 0.0;
   *kappa = interp.interpolate(map->convergence);
   *phi = interp.interpolate(map->phi);
-    
-	return;
+  
+  return;
 }
 
 /**
@@ -502,8 +503,8 @@ void LensHaloMassMap::estSignLambdas(){
   int i, j;
   for(i=0;i<map->nx;i++)
     for(j=0;j<map->ny;j++){
-      gamma = sqrt(pow(map->gamma1[i+map->ny*j],2) + 
-			  pow(map->gamma2[i+map->ny*j],2));
+      gamma = sqrt(pow(map->gamma1[i+map->ny*j],2) +
+                   pow(map->gamma2[i+map->ny*j],2));
       lambdat=1-map->convergence[i+map->ny*j]-gamma;
       lambdar=1-map->convergence[i+map->ny*j]+gamma;
       
@@ -511,12 +512,12 @@ void LensHaloMassMap::estSignLambdas(){
       else map->Signlambdar[i+map->ny*j]=-1;
       
       if(lambdat>=0) map->Signlambdat[i+map->ny*j]=1;
-      else map->Signlambdat[i+map->ny*j]=-1;     
+      else map->Signlambdat[i+map->ny*j]=-1;
     }
 }
 
 /**
- * measure the effective and the median Einstein radii of the connected critical 
+ * measure the effective and the median Einstein radii of the connected critical
  * points present at the halo center
  */
 void LensHaloMassMap::EinsteinRadii(double &RE1, double &RE2, double &xxc, double &yyc){
@@ -555,7 +556,7 @@ void LensHaloMassMap::EinsteinRadii(double &RE1, double &RE2, double &xxc, doubl
   filoutcrit.close();
   double pixDinL = map->boxlMpc/double(map->nx);
   /* measure the Einstein radius */
-  std:: vector<double> xci,yci;	
+  std:: vector<double> xci,yci;
   //for(int ii=0;ii<xci1.size();ii++){
   //  xci.push_back(xci1[ii]);
   //  yci.push_back(yci1[ii]);
@@ -577,28 +578,28 @@ void LensHaloMassMap::EinsteinRadii(double &RE1, double &RE2, double &xxc, doubl
     double yercm=0;
     for(int ii=0;ii<nc;ii++){
       if(groupid[ii] == nearest0groupid){
-	xcpoints.push_back(xci[ii]);
-	ycpoints.push_back(yci[ii]);
-	xercm+=xci[ii];
-	yercm+=yci[ii];
+        xcpoints.push_back(xci[ii]);
+        ycpoints.push_back(yci[ii]);
+        xercm+=xci[ii];
+        yercm+=yci[ii];
       }
     }
     nc = xcpoints.size();
     xercm=xercm/double(nc);
     yercm=yercm/double(nc);
     double distcentre=sqrt((xercm-xxc)*(xercm-xxc)+(yercm-yyc)*(yercm-yyc))*map->inarcsec;
-    std:: vector<double>::iterator maxit, minit; 
+    std:: vector<double>::iterator maxit, minit;
     // find the min and max elements in the vector
     maxit = max_element(xcpoints.begin(), xcpoints.end());
     minit = min_element(xcpoints.begin(), xcpoints.end());
     double xmincpoints,xmaxcpoints;
     xmaxcpoints = *maxit;
     xmincpoints = *minit;
-      int imin = Utilities::locate(map->x,xmincpoints);
+    int imin = Utilities::locate(map->x,xmincpoints);
     imin = ((imin > 0) ? imin:0);
     imin = ((imin < map->nx-1) ? imin:map->nx-1);
     // imin=GSL_MIN( GSL_MAX( imin, 0 ), map->nx-1 );
-      int imax = Utilities::locate(map->x,xmaxcpoints);
+    int imax = Utilities::locate(map->x,xmaxcpoints);
     imax = ((imax > 0) ? imax:0);
     imax = ((imax < map->nx-1) ? imax:map->nx-1);
     // imax=GSL_MIN( GSL_MAX( imax, 0 ), map->nx-1 );
@@ -607,33 +608,33 @@ void LensHaloMassMap::EinsteinRadii(double &RE1, double &RE2, double &xxc, doubl
       std:: vector<double>ybut;
       int condition=0;
       for(int ji=0;ji<nc;ji++){
-	if(fabs(xcpoints[ji]-map->x[ii])<pixDinL/2){
-	  if(condition==0){
-	    xsup.push_back(xcpoints[ji]);
-	    xinf.push_back(xcpoints[ji]);
-	    condition=1;
-	  }
-	  ybut.push_back(ycpoints[ji]);
-	}
+        if(fabs(xcpoints[ji]-map->x[ii])<pixDinL/2){
+          if(condition==0){
+            xsup.push_back(xcpoints[ji]);
+            xinf.push_back(xcpoints[ji]);
+            condition=1;
+          }
+          ybut.push_back(ycpoints[ji]);
+        }
       }
       if(ybut.size()>0){
-	std:: vector<double>::iterator ymax, ymin; 
-	// Find the min and max elements in the vector
-	ymax = max_element(ybut.begin(), ybut.end());
-	ymin = min_element(ybut.begin(), ybut.end());
-	double ymincpoints,ymaxcpoints;
-	ymaxcpoints = *ymax;
-	ymincpoints = *ymin;  
-	ysup.push_back(ymaxcpoints);
-	yinf.push_back(ymincpoints);
-      }  
+        std:: vector<double>::iterator ymax, ymin;
+        // Find the min and max elements in the vector
+        ymax = max_element(ybut.begin(), ybut.end());
+        ymin = min_element(ybut.begin(), ybut.end());
+        double ymincpoints,ymaxcpoints;
+        ymaxcpoints = *ymax;
+        ymincpoints = *ymin;
+        ysup.push_back(ymaxcpoints);
+        yinf.push_back(ymincpoints);
+      }
       if(ybut.size()==1){
-	double ymincpoints,ymaxcpoints;
-	ymaxcpoints = ybut[0];
-	ymincpoints = ybut[0];
-	ysup.push_back(ymaxcpoints);
-	yinf.push_back(ymincpoints);
-      }  
+        double ymincpoints,ymaxcpoints;
+        ymaxcpoints = ybut[0];
+        ymincpoints = ybut[0];
+        ysup.push_back(ymaxcpoints);
+        yinf.push_back(ymincpoints);
+      }
     }
     nc = yinf.size();
     int npixIN=0;
@@ -642,9 +643,9 @@ void LensHaloMassMap::EinsteinRadii(double &RE1, double &RE2, double &xxc, doubl
       RE.push_back(sqrt(pow(xinf[ii]-xercm,2.) + pow(yinf[ii]-yercm,2)));
       std:: vector<double> ycounts;
       for(int ji=0;ji<map->nx;ji++){
-	if(map->x[ji]>=yinf[ii] && map->x[ji]<=ysup[ii]){
-	  ycounts.push_back(map->x[ji]);
-	}
+        if(map->x[ji]>=yinf[ii] && map->x[ji]<=ysup[ii]){
+          ycounts.push_back(map->x[ji]);
+        }
       }
       int ncounts = ycounts.size();
       npixIN=npixIN+ncounts;
@@ -672,36 +673,36 @@ void LensHaloMassMap::EinsteinRadii(double &RE1, double &RE2, double &xxc, doubl
  * of the convergence and shear
  */
 void LensHaloMassMap::saveImage(bool saveprofiles){
-        std::stringstream f;
-        std::string filename;  
-	if(flag_background_field==1) f << MOKA_input_file << "_only_noise.fits";
-	else{
-	  if(flag_MOKA_analyze == 0) f << MOKA_input_file << "_noisy.fits";
-	  else f << MOKA_input_file << "_no_noise.fits";
-	}
-	filename = f.str();
-
-	writeImage(filename);
-	
-	if(saveprofiles == true){
-	  std:: cout << " saving profile " << std:: endl;
-	            double RE3,xxc,yyc;
-	            saveProfiles(RE3,xxc,yyc);
-		    estSignLambdas(); 
-		    double RE1,RE2;
-		    EinsteinRadii(RE1,RE2,xxc,yyc);
-		    std::ostringstream fEinr;
-		    if(flag_background_field==1) fEinr << MOKA_input_file << "_only_noise_Einstein.radii.dat";
-		    else{
-		      if(flag_MOKA_analyze == 0) fEinr << MOKA_input_file << "_noisy_Einstein.radii.dat";
-		      else fEinr << MOKA_input_file << "_no_noise_Einstein.radii.dat";
-		    }
-		    std:: ofstream filoutEinr;
-		    std:: string filenameEinr = fEinr.str();
-		    filoutEinr.open(filenameEinr.c_str());
-		    filoutEinr << "# effective        median      from_profles" << std:: endl;
-		    filoutEinr << RE1 << "   " << RE2 << "    " << RE3 << std:: endl;
-		    filoutEinr.close();
-	}
+  std::stringstream f;
+  std::string filename;
+  if(flag_background_field==1) f << MOKA_input_file << "_only_noise.fits";
+  else{
+    if(flag_MOKA_analyze == 0) f << MOKA_input_file << "_noisy.fits";
+    else f << MOKA_input_file << "_no_noise.fits";
+  }
+  filename = f.str();
+  
+  writeImage(filename);
+  
+  if(saveprofiles == true){
+    std:: cout << " saving profile " << std:: endl;
+    double RE3,xxc,yyc;
+    saveProfiles(RE3,xxc,yyc);
+    estSignLambdas();
+    double RE1,RE2;
+    EinsteinRadii(RE1,RE2,xxc,yyc);
+    std::ostringstream fEinr;
+    if(flag_background_field==1) fEinr << MOKA_input_file << "_only_noise_Einstein.radii.dat";
+    else{
+      if(flag_MOKA_analyze == 0) fEinr << MOKA_input_file << "_noisy_Einstein.radii.dat";
+      else fEinr << MOKA_input_file << "_no_noise_Einstein.radii.dat";
+    }
+    std:: ofstream filoutEinr;
+    std:: string filenameEinr = fEinr.str();
+    filoutEinr.open(filenameEinr.c_str());
+    filoutEinr << "# effective        median      from_profles" << std:: endl;
+    filoutEinr << RE1 << "   " << RE2 << "    " << RE3 << std:: endl;
+    filoutEinr.close();
+  }
 }
 

--- a/MultiPlane/lens.cpp
+++ b/MultiPlane/lens.cpp
@@ -325,6 +325,9 @@ void Lens::assignParams(InputParams& params,bool verbose)
     if(!params.get("pixelmaps_padding_factor",pixel_map_zeropad)){
       pixel_map_zeropad = 4;
     }
+    if(!params.get("pixelmaps_zeromean",pixel_map_zeromean)){
+      pixel_map_zeromean = true;
+    }
 	}
 	
 	if(!params.get("z_source",zsource))

--- a/MultiPlane/lens_multi_dark.cpp
+++ b/MultiPlane/lens_multi_dark.cpp
@@ -16,12 +16,13 @@ void Lens::readPixelizedDensity()
 	if(!list.good())
 	{
 		std::cerr << "Cannot open file " << pixel_map_input_file << std::endl;
-		throw std::runtime_error("Could not open PixelDMap list file" + pixel_map_input_file + "!");
+		throw std::runtime_error("Could not open PixelDMap list file " + pixel_map_input_file + "!");
 	}
 	
   if(pixel_map_input_file.find(".fits") != pixel_map_input_file.npos){
     std::cout << "inputing PixelDensityMap file: " << pixel_map_input_file << std::endl;
-    main_halos.push_back(new LensHaloMassMap(pixel_map_input_file, pix_map, pixel_map_zeropad,cosmo));
+    main_halos.push_back(new LensHaloMassMap(pixel_map_input_file, pix_map, pixel_map_zeropad
+                                             ,pixel_map_zeromean,cosmo));
   }else{
     
     std::cout << "reading PixelDMap files: " << pixel_map_input_file << std::endl;
@@ -52,7 +53,7 @@ void Lens::readPixelizedDensity()
       std::cout << "- " << mokafile << std::endl;
       
       // create the MOKA halo
-      main_halos.push_back(new LensHaloMassMap(mokafile, pix_map,pixel_map_zeropad, cosmo));
+      main_halos.push_back(new LensHaloMassMap(mokafile, pix_map,pixel_map_zeropad,pixel_map_zeromean, cosmo));
     }
   }
 }

--- a/include/MOKAlens.h
+++ b/include/MOKAlens.h
@@ -63,7 +63,8 @@ class LensHaloMassMap : public LensHalo
 {
 public:
 	LensHaloMassMap(const std::string& filename, PixelMapType maptype,
-                  int pixel_map_zeropad, const COSMOLOGY& lenscosmo);
+                  int pixel_map_zeropad,bool my_zeromean, const COSMOLOGY& lenscosmo);
+  
 	LensHaloMassMap(InputParams& params, const COSMOLOGY& lenscosmo);
 	
 	~LensHaloMassMap();
@@ -110,6 +111,7 @@ private:
 	const COSMOLOGY& cosmo;
 	void PreProcessFFTWMap();
   int zerosize;
+  bool zeromean;
 };
   
 

--- a/include/lens.h
+++ b/include/lens.h
@@ -443,6 +443,7 @@ private: /* input */
   short pixel_map_on;
   /// zero padding for FFTs with pixelized density maps
   int pixel_map_zeropad;
+  bool pixel_map_zeromean;
 	void readPixelizedDensity();
   
   /// the center of the lens in spherical coordinates


### PR DESCRIPTION
@liran827 I have added the parameter `pixelmap_zeromean' which if set to`false` will disable the subtraction of the average density from the pixel mass map for testing purposes.  Default value is true and this is what you will want when putting in maps from a simulation.

I have reproduced your test with a SIS and find that the magnitude of the deflection is constant within the SIS at the few percent level.  This discrepancy I think is because of the interpolation from the mass map grid.  If a very high resolution is used for the mass map I think you would get a more accurate alpha map.  Remember also that the map must include all of the SIS profile.  If the SIS extends out further than the boundaries of the map there will be artefacts from it not being perfectly symmetric.

Try your test with the `pixelmap_zeromean'  parameter set to 'false' and let me know what happens.
