### PR TITLE
Corrected the sign of the deflection for pixelmap input lenses.

### DIFF
--- a/MultiPlane/MOKAfits.cpp
+++ b/MultiPlane/MOKAfits.cpp
@@ -720,7 +720,7 @@ void LensHaloMassMap::readMap(){
           int ii = i-int(Nnx/2-map->nx/2);
           int jj = j-int(Nny/2-map->ny/2);
           
-          map->alpha1[ii+map->nx*jj] = float(realsp[i+Nnx*j]/Nnx/Nny);
+          map->alpha1[ii+map->nx*jj] = -1*float(realsp[i+Nnx*j]/Nnx/Nny);
         }
     }
     
@@ -753,7 +753,7 @@ void LensHaloMassMap::readMap(){
           int ii = i-int(Nnx/2-map->nx/2);
           int jj = j-int(Nny/2-map->ny/2);
           
-          map->alpha2[ii+map->nx*jj] = float(realsp[i+Nnx*j]/Nnx/Nny);
+          map->alpha2[ii+map->nx*jj] = -1*float(realsp[i+Nnx*j]/Nnx/Nny);
         }
       }
     }

--- a/TreeCode_link/List/list.cpp
+++ b/TreeCode_link/List/list.cpp
@@ -348,3 +348,9 @@ void PointList::PrintList(){
   }
 
 }
+
+std::ostream &operator<<(std::ostream &os, Point_2d const &p) {
+ return os << p.x[0] << " " << p.x[1];
+ }
+
+

--- a/TreeCode_link/image_finder_kist.cpp
+++ b/TreeCode_link/image_finder_kist.cpp
@@ -85,6 +85,8 @@ void ImageFinding::find_images_kist(
   
   if(r_source==0.0){ERROR_MESSAGE(); printf("ERROR: find_images, point source must have a resolution target\n"); exit(1);}
   
+  if(grid->getInitRange() < 2*r_source ){std::cerr << "Warning: In ImageFinding::find_images_kist() source size is larger than grid size.  Continuing but might cause problems." << std::endl;}
+  
   if(initial_size==0 || grid->getNumberOfPoints() == grid->getInitNgrid()*grid->getInitNgrid())
     initial_size=grid->getInitRange()/grid->getInitNgrid();
   
@@ -249,7 +251,7 @@ void ImageFinding::find_images_kist(
   
   time(&now);
   
-  assert(*Nimages > 0);
+  //assert(*Nimages > 0);
   // do an initial uniform refinement to make sure there are enough point in
   //  the images
   i=0;

--- a/include/point.h
+++ b/include/point.h
@@ -365,5 +365,6 @@ struct Point_2d{
   PosType & operator[](size_t i){return x[i];}
 };
 
+std::ostream &operator<<(std::ostream &os, Point_2d const &p);
 
 #endif


### PR DESCRIPTION
This is a bug fix that changes the sign of the deflection after is calculated from FFTing mass maps.  The problem was noticed by @liran827.  
