### PR TITLE
reimplemented LensHaloMassMap::getN() with check for squareness

### DIFF
--- a/include/MOKAlens.h
+++ b/include/MOKAlens.h
@@ -15,6 +15,8 @@
 #include "lens_halos.h"
 #include "grid_maintenance.h"
 
+#include <stdexcept>
+
 /**
  * \brief The MOKA map structure, containing all quantities that define it
  *
@@ -100,10 +102,17 @@ public:
 	double getRangeRad() const { return map->boxlrad; }
 	/// return range of input map in physical Mpc
 	double getRangeMpc() const { return map->boxlMpc; }
-  /// return number of pixels on a x-axis side in original map
-  size_t getNx() const { return map->nx; }
-  /// return number of pixels on a y-axis side in original map
-  size_t getNy() const { return map->ny; }
+	/// /// return number of pixels on a side in original map
+	size_t getN() const
+	{
+		if(map->nx != map->ny)
+			throw std::runtime_error("mass map is not square");
+		return map->nx;
+	}
+	/// return number of pixels on a x-axis side in original map
+	size_t getNx() const { return map->nx; }
+	/// return number of pixels on a y-axis side in original map
+	size_t getNy() const { return map->ny; }
 	
 private:
 	PixelMapType maptype;


### PR DESCRIPTION
This PR adds a `LensHaloMassMap::getN()` method that throws an error if the map is not square.
