### PR TITLE
add GSL include dirs necessary for CosmoLib headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,11 @@ endif()
 if(ENABLE_FFTW)
 	include_directories(${FFTW3_INCLUDE_DIRS})
 endif()
+
+if(ENABLE_GSL)
+	include_directories(${GSL_INCLUDE_DIRS})
+endif()
+
 if(ENABLE_HEALPIX)
 	include_directories(${HEALPIX_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
The include directory of GSL is required in SLsimLib as well through the inclusion of the `cosmo.h` header.
