### PR TITLE
Replaced the exponential smoothing

### DIFF
--- a/TreeCode/qTreeNB.cpp
+++ b/TreeCode/qTreeNB.cpp
@@ -47,6 +47,7 @@ QTreeNB::QTreeNB(PosType **xp,IndexType *particles,IndexType nparticles
 
     Nbranches = 1;
     current = top;
+
 }
 
 /// Free treeNB. Does not free the particle positions, masses or sizes

--- a/TreeCode/quadTree.cpp
+++ b/TreeCode/quadTree.cpp
@@ -44,6 +44,7 @@ TreeQuad::TreeQuad(
 
 	CalcMoments();
   
+  phiintconst = (120*log(2.) - 631.)/840 + 19./70;
 	return;
 }
 /** \brief Constructor meant for halos with internal structure parameters.  This is a protected constructor because
@@ -78,6 +79,7 @@ MultiMass(true),MultiRadius(true),masses(NULL),sizes(NULL)
 
 	CalcMoments();
 
+  phiintconst = (120*log(2.) - 631.)/840 + 19./70;
 	return;
 }
 
@@ -686,8 +688,11 @@ void TreeQuad::walkTree_iter(
               PosType size = sizes[tmp_index*MultiRadius];
               
 						  // intersecting, subtract the point particle
-						  if(rcm2 < 9*size*size)
+						  if(rcm2 < 4*size*size)
               {
+                
+                b_spline_profile(xcm,sqrt(rcm2),masses[MultiMass*tmp_index],size,alpha,kappa,gamma,phi);
+                /*
                 prefac = masses[MultiMass*tmp_index]/rcm2/pi;
                 arg1 = rcm2/(size*size);
 
@@ -695,18 +700,18 @@ void TreeQuad::walkTree_iter(
 							  alpha[0] += tmp*xcm[0];
 							  alpha[1] += tmp*xcm[1];
                 
-                {
-								  *kappa += kappa_h(arg1,size)*prefac;
+    
+                *kappa += kappa_h(arg1,size)*prefac;
                   
-								  tmp = (gamma_h(arg1,size) + 2.0)*prefac/rcm2;
+                tmp = (gamma_h(arg1,size) + 2.0)*prefac/rcm2;
                   
-								  gamma[0] += 0.5*(xcm[0]*xcm[0]-xcm[1]*xcm[1])*tmp;
-								  gamma[1] += xcm[0]*xcm[1]*tmp;
-                  
+                gamma[0] += 0.5*(xcm[0]*xcm[0]-xcm[1]*xcm[1])*tmp;
+                gamma[1] += xcm[0]*xcm[1]*tmp;
+                
+                */
                   // TODO: makes sure the normalization of phi_h agrees with this
-                  *phi += (phi_h(arg1,size) + 0.5*log(rcm2))*prefac*rcm2;
-                  
-							  }
+                //*phi += (phi_h(arg1,size) + 0.5*log(rcm2))*prefac*rcm2;
+                
 						  }
 					  }
 				  }
@@ -921,13 +926,16 @@ void TreeQuad::walkTree_recur(QBranchNB *branch,PosType const *ray,PosType *alph
  					}else{  // case of no halos just particles and no class derived from TreeQuad
             
 						if(rcm2 < 1e-20) rcm2 = 1e-20;
-						//rcm = sqrt(rcm2);
             
             PosType size = sizes[tmp_index*MultiRadius];
             
 						// intersecting, subtract the point particle
-						if(rcm2 < 9*size*size)
+						if(rcm2 < 4*size*size)
             {
+              
+              b_spline_profile(xcm,sqrt(rcm2),masses[MultiMass*tmp_index],size,alpha,kappa,gamma,phi);
+              
+              /*
               prefac = masses[MultiMass*tmp_index]/rcm2/pi;
               arg1 = rcm2/(size*size);
               arg2 = size;
@@ -936,17 +944,18 @@ void TreeQuad::walkTree_recur(QBranchNB *branch,PosType const *ray,PosType *alph
 							alpha[0] += tmp*xcm[0];
 							alpha[1] += tmp*xcm[1];
               
-							{
-								*kappa += kappa_h(arg1,arg2)*prefac;
+							
+              *kappa += kappa_h(arg1,arg2)*prefac;
                 
-								tmp = (gamma_h(arg1,arg2) + 2.0)*prefac/rcm2;
+              tmp = (gamma_h(arg1,arg2) + 2.0)*prefac/rcm2;
                 
-								gamma[0] += 0.5*(xcm[0]*xcm[0]-xcm[1]*xcm[1])*tmp;
-								gamma[1] += xcm[0]*xcm[1]*tmp;
+              gamma[0] += 0.5*(xcm[0]*xcm[0]-xcm[1]*xcm[1])*tmp;
+              gamma[1] += xcm[0]*xcm[1]*tmp;
                 
                 // TODO: makes sure the normalization of phi_h agrees with this
-                *phi += (phi_h(arg1,arg2) + 0.5*log(rcm2))*prefac*rcm2;
-							}
+              *phi += (phi_h(arg1,arg2) + 0.5*log(rcm2))*prefac*rcm2;
+
+              */
 						}
 					}
 				}

--- a/TreeCode/quadTree.cpp
+++ b/TreeCode/quadTree.cpp
@@ -692,26 +692,6 @@ void TreeQuad::walkTree_iter(
               {
                 
                 b_spline_profile(xcm,sqrt(rcm2),masses[MultiMass*tmp_index],size,alpha,kappa,gamma,phi);
-                /*
-                prefac = masses[MultiMass*tmp_index]/rcm2/pi;
-                arg1 = rcm2/(size*size);
-
-                tmp = (alpha_h(arg1,size) + 1.0)*prefac;
-							  alpha[0] += tmp*xcm[0];
-							  alpha[1] += tmp*xcm[1];
-                
-    
-                *kappa += kappa_h(arg1,size)*prefac;
-                  
-                tmp = (gamma_h(arg1,size) + 2.0)*prefac/rcm2;
-                  
-                gamma[0] += 0.5*(xcm[0]*xcm[0]-xcm[1]*xcm[1])*tmp;
-                gamma[1] += xcm[0]*xcm[1]*tmp;
-                
-                */
-                  // TODO: makes sure the normalization of phi_h agrees with this
-                //*phi += (phi_h(arg1,size) + 0.5*log(rcm2))*prefac*rcm2;
-                
 						  }
 					  }
 				  }
@@ -935,27 +915,6 @@ void TreeQuad::walkTree_recur(QBranchNB *branch,PosType const *ray,PosType *alph
               
               b_spline_profile(xcm,sqrt(rcm2),masses[MultiMass*tmp_index],size,alpha,kappa,gamma,phi);
               
-              /*
-              prefac = masses[MultiMass*tmp_index]/rcm2/pi;
-              arg1 = rcm2/(size*size);
-              arg2 = size;
-              
-							tmp = (alpha_h(arg1,arg2) + 1.0)*prefac;
-							alpha[0] += tmp*xcm[0];
-							alpha[1] += tmp*xcm[1];
-              
-							
-              *kappa += kappa_h(arg1,arg2)*prefac;
-                
-              tmp = (gamma_h(arg1,arg2) + 2.0)*prefac/rcm2;
-                
-              gamma[0] += 0.5*(xcm[0]*xcm[0]-xcm[1]*xcm[1])*tmp;
-              gamma[1] += xcm[0]*xcm[1]*tmp;
-                
-                // TODO: makes sure the normalization of phi_h agrees with this
-              *phi += (phi_h(arg1,arg2) + 0.5*log(rcm2))*prefac*rcm2;
-
-              */
 						}
 					}
 				}

--- a/include/quadTree.h
+++ b/include/quadTree.h
@@ -261,18 +261,18 @@ protected:
 	}
 
   
-  /* cubic B-spline kernal for particle profile
+  /* cubic B-spline kernel for particle profile
    
-   The lensing qunatities are added to and a point mass is subtacted
+   The lensing quantities are added to and a point mass is subtracted
   */
-  void b_spline_profile(
-                        PosType *xcm
-                        ,PosType r       // distance from center in Mpc
-                        ,PosType Mass
-                        ,PosType size    // size scale in Mpc
-                        ,PosType *alpha
-                        ,KappaType *kappa
-                        ,KappaType *gamma
+  inline void b_spline_profile(
+                        PosType *xcm       // vector in Mpc connecting ray to center of particle
+                        ,PosType r         // distance from center in Mpc
+                        ,PosType Mass      // mass in solar masses
+                        ,PosType size      // size scale in Mpc
+                        ,PosType *alpha    // deflection angle times Sigma_crit
+                        ,KappaType *kappa  // surface density
+                        ,KappaType *gamma  // shear times Sigma_crit
                         ,KappaType *phi
                        ) const {
     
@@ -310,7 +310,41 @@ protected:
     *phi -= Mass*log(r)/pi;
   }
   
-  
+  /* Exponential kernel for particle profile
+   
+   The lensing quantities are added to and a point mass is subtracted
+   */
+  inline void exponential_profile(
+                        PosType *xcm
+                        ,PosType rcm2       // distance from center in Mpc
+                        ,PosType Mass
+                        ,PosType size    // size scale in Mpc
+                        ,PosType *alpha
+                        ,KappaType *kappa
+                        ,KappaType *gamma
+                        ,KappaType *phi
+                        ) const {
+    
+    
+     PosType prefac = Mass/rcm2/pi;
+     PosType arg1 = rcm2/(size*size);
+     
+     PosType tmp = (alpha_h(arg1,size) + 1.0)*prefac;
+     alpha[0] += tmp*xcm[0];
+     alpha[1] += tmp*xcm[1];
+     
+     
+     *kappa += kappa_h(arg1,size)*prefac;
+     
+     tmp = (gamma_h(arg1,size) + 2.0)*prefac/rcm2;
+     
+     gamma[0] += 0.5*(xcm[0]*xcm[0]-xcm[1]*xcm[1])*tmp;
+     gamma[1] += xcm[0]*xcm[1]*tmp;
+     
+    // TODO: makes sure the normalization of phi_h agrees with this
+    //*phi += (phi_h(arg1,size) + 0.5*log(rcm2))*prefac*rcm2;
+  }
+
 	QTreeNBHndl rotate_simulation(PosType **xp,IndexType Nparticles,IndexType *particles
 			,PosType **coord,PosType theta,float *rsph,float *mass
 			,bool MultiRadius,bool MultiMass);


### PR DESCRIPTION
In this PR the exponential smoothing of simulation particles in LensHaloParticles is replaced with a cubic B-spline smoothing.

This should make the lensing quantities more self consistent.  Test show that this is the case although this was not a big problem previously.  

For the same number of nearest neighbours more detail should be represented.

The force solver should be faster because all the mass is confined to a radius of twice the particle size and not 3 times.

I have also implemented the time delay for simulation particles.  This could slow it down.  I have not yet tested the accuracy  of this.