### PR TITLE
Generate field of halos in the whole light-cone

### DIFF
--- a/MultiPlane/lens.cpp
+++ b/MultiPlane/lens.cpp
@@ -59,7 +59,7 @@ Lens::Lens(long* my_seed,PosType z_source, CosmoParamSet cosmoset,bool verbose)
   combinePlanes(verbose);
   if(zsource != ztmp) ResetSourcePlane(ztmp,false);
 
-  std::cout << "number of field halos :" << field_halos.size() << std::endl;
+  //std::cout << "number of field halos :" << field_halos.size() << std::endl;
 }
 
 Lens::Lens(long* my_seed,PosType z_source, const COSMOLOGY &cosmoset,bool verbose)
@@ -85,7 +85,7 @@ Lens::Lens(long* my_seed,PosType z_source, const COSMOLOGY &cosmoset,bool verbos
   PosType ztmp = zsource;
   combinePlanes(true);
   if(zsource != ztmp) ResetSourcePlane(ztmp,false);
-  std::cout << "number of field halos :" << field_halos.size() << std::endl;
+  //std::cout << "number of field halos :" << field_halos.size() << std::endl;
 }
 
 /**
@@ -856,14 +856,8 @@ void Lens::createFieldPlanes(bool verbose)
 			     
       assert( field_Dl[i] > 0 );
 			// convert to proper distance on the lens plane
-      //field_halos[j]->getX(tmp);
-      //field_halos[j]->setX(tmp[0]*field_Dl[i]/(1+field_plane_redshifts[i])
-      //                     ,tmp[1]*field_Dl[i]/(1+field_plane_redshifts[i]));
-      //field_halos[j]->setDist(field_Dl[i]/(1+field_plane_redshifts[i]));
       
       field_halos[j]->setZlensDist(field_plane_redshifts[i],cosmo);
-      //halo_pos[j][0] *= field_Dl[i]/(1+field_plane_redshifts[i]);
-			//halo_pos[j][1] *= field_Dl[i]/(1+field_plane_redshifts[i]);
 		}
 		
 		//max_r=sqrt(max_r);
@@ -1707,7 +1701,7 @@ void Lens::createFieldHalos(bool verbose)
 			maxr = pi*sqrt(fieldofview/pi)/180. + field_buffer/Ds; // fov is a circle
 			rr = maxr*sqrt(ran2(seed));
       
-      if(verbose) std::cout << "          maxr = " << maxr << std::endl;
+      //if(verbose) std::cout << "          maxr = " << maxr << std::endl;
 
 			assert(rr == rr);
       
@@ -2963,6 +2957,42 @@ void Lens::buildPlanes(InputParams& params, bool verbose)
 	
 	// combine the different planes
 	combinePlanes(verbose);
+}
+
+void Lens::GenerateFieldHalos(double min_mass
+                         ,MassFuncType mass_function
+                         ,double field_of_view
+                         ,int Nplanes
+                         ,LensHaloType halo_type
+                         ,bool verbose
+                         ){
+
+  if(field_halos.size() >0 ){
+    std::cerr << "Lens:GenerateField() cannot be used in the lens already has field halos." << std::endl;
+    throw std::runtime_error("Field halos already exist.");
+  }
+  field_min_mass = min_mass;
+  fieldofview = field_of_view;
+  field_mass_func_type = mass_function;
+
+  field_buffer = 0.0;
+
+  mass_func_PL_slope = 0;
+  flag_field_gal_on = false;
+  field_int_prof_type = halo_type;
+  field_int_prof_gal_type = nsie_gal;
+
+  NhalosbinZ.resize(Nzbins);
+  Nhaloestot_Tab.resize(NZSamples);
+  ComputeHalosDistributionVariables();
+  
+  field_Nplanes_original = field_Nplanes_current = Nplanes;
+  setupFieldPlanes();
+
+  //resetFieldHalos();
+  createFieldHalos(verbose);
+  createFieldPlanes(verbose);
+  combinePlanes(verbose);
 }
 
 /**

--- a/MultiPlane/lens_halos.cpp
+++ b/MultiPlane/lens_halos.cpp
@@ -134,12 +134,25 @@ PosType* LensHaloNFW::xgtable = NULL;
 PosType*** LensHaloNFW::modtable= NULL; // was used for Ansatz IV
 
 
-
 LensHaloNFW::LensHaloNFW()
 : LensHalo(), gmax(0)
 {
+  
+  LensHalo::setRsize(1.0);
+  Rmax = LensHalo::getRsize();
+
+  LensHalo::setMass(0.0);
+  LensHalo::setZlens(0);
+  
+  fratio=1;
+  pa = stars_N = 0;
+  stars_implanted = false;
+  rscale = LensHalo::getRsize()/5;
+  xmax = LensHalo::getRsize()/rscale;
+
   make_tables();
   gmax = InterpolateFromTable(gtable, xmax);
+  set_flag_elliptical(false);
 }
 
 LensHaloNFW::LensHaloNFW(float my_mass,float my_Rsize,PosType my_zlens,float my_concentration,float my_fratio,float my_pa,int my_stars_N, EllipMethod my_ellip_method){

--- a/TreeCode/qTreeNB.cpp
+++ b/TreeCode/qTreeNB.cpp
@@ -62,6 +62,7 @@ QTreeNB::~QTreeNB(){
 
 short QTreeNB::empty(){
 
+  if(Nbranches <= 1) return;
 	moveTop();
 	_freeQTree(0);
 

--- a/TreeCode/qTreeNB.cpp
+++ b/TreeCode/qTreeNB.cpp
@@ -62,7 +62,7 @@ QTreeNB::~QTreeNB(){
 
 short QTreeNB::empty(){
 
-  if(Nbranches <= 1) return;
+  if(Nbranches <= 1) return 1;
 	moveTop();
 	_freeQTree(0);
 

--- a/TreeCode/quadTree.cpp
+++ b/TreeCode/quadTree.cpp
@@ -75,9 +75,11 @@ MultiMass(true),MultiRadius(true),masses(NULL),sizes(NULL)
 
 	haloON = true;  //use internal halo parameters
 
-	tree = BuildQTreeNB(xp,Npoints,index);
+  if(Npoints > 0){
+    tree = BuildQTreeNB(xp,Npoints,index);
 
-	CalcMoments();
+    CalcMoments();
+  }
 
   phiintconst = (120*log(2.) - 631.)/840 + 19./70;
 	return;
@@ -86,6 +88,7 @@ MultiMass(true),MultiRadius(true),masses(NULL),sizes(NULL)
 /// Particle positions and other data are not destroyed.
 TreeQuad::~TreeQuad()
 {
+  if(Nparticles == 0) return;
 	delete tree;
 	delete[] index;
   if(haloON) Utilities::free_PosTypeMatrix(xp,Nparticles,2);
@@ -494,12 +497,15 @@ void TreeQuad::rotate_coordinates(PosType **coord){
 
 void TreeQuad::force2D(const PosType *ray,PosType *alpha,KappaType *kappa,KappaType *gamma,KappaType *phi) const{
   
+  alpha[0]=alpha[1]=gamma[0]=gamma[1]=gamma[2]=0.0;
+  *kappa=*phi=0.0;
+  
+  if(Nparticles == 0) return;
+
   assert(tree);
   QTreeNB::iterator it(tree);
   
-  alpha[0]=alpha[1]=gamma[0]=gamma[1]=gamma[2]=0.0;
-  *kappa=*phi=0.0;
-    
+  
   if(periodic_buffer){
     PosType tmp_ray[2];
         
@@ -777,10 +783,12 @@ void TreeQuad::walkTree_iter(
 
 void TreeQuad::force2D_recur(const PosType *ray,PosType *alpha,KappaType *kappa,KappaType *gamma,KappaType *phi){
   
-  assert(tree);
   
   alpha[0]=alpha[1]=gamma[0]=gamma[1]=gamma[2]=0.0;
   *kappa=*phi=0.0;
+  
+  if(Nparticles == 0) return;
+  assert(tree);
   
   //walkTree_recur(tree->top,ray,&alpha[0],kappa,&gamma[0],phi);
   

--- a/include/analytic_lens.h
+++ b/include/analytic_lens.h
@@ -18,6 +18,9 @@
  */
 // TODO: BEN finish this documentation for perturbation parameters.
 class LensHaloFit : public LensHaloBaseNSIE{
+  
+  void abstractfunction(){}; // pure virtual
+  
 public:
   //LensHaloAnaNSIE(InputParams& params,bool verbose = false);
   /// Creates a AnaLens which initially has no mass,  Use FindLensSimple() to give it mass
@@ -128,6 +131,9 @@ private:
  */
 // TODO: BEN finish this documentation for perturbation parameters.
 class LensHaloAnaNSIE : public LensHaloBaseNSIE{
+  
+  void abstractfunction(){}; // pure virtual
+
 public:
   LensHaloAnaNSIE(InputParams& params,bool verbose = false);
   /// Creates a AnaLens which initially has no mass,  Use FindLensSimple() to give it mass

--- a/include/base_analens.h
+++ b/include/base_analens.h
@@ -54,6 +54,8 @@ class LensHaloBaseNSIE : public LensHalo{
 public:
 	LensHaloBaseNSIE(InputParams& params);
   LensHaloBaseNSIE();
+  
+  virtual void abstractfunction() = 0; // pure virtual
 
   virtual ~LensHaloBaseNSIE();
 

--- a/include/lens.h
+++ b/include/lens.h
@@ -85,10 +85,10 @@ public:
 	bool set;
 
 	/// the total number of lens planes
-	int getNplanes(){return lensing_planes.size();}
+	int getNplanes() const {return lensing_planes.size();}
   
 	/// field of view in square degrees
-	PosType getfov(){return fieldofview;};
+	PosType getfov() const {return fieldofview;};
 	void setfov(PosType fov){fieldofview=fov;};
 
 	/// reset the number of planes, but keep the field halos and main lens
@@ -105,7 +105,7 @@ public:
 
   
   /// Redshift of first main lens plane
-	PosType getZlens(){
+	PosType getZlens() const{
 		if(flag_switch_main_halo_on)
 			return main_halos[0]->getZlens();
 		else{
@@ -115,7 +115,7 @@ public:
 		}
 	}
   /// Angular size distance (Mpc) to first main lens plane
-	PosType getAngDistLens(){
+	PosType getAngDistLens() const{
 		if(flag_switch_main_halo_on)
 			return cosmo.angDist( main_halos[0]->getZlens());
 		else{
@@ -124,6 +124,8 @@ public:
 			exit(1);
 		}
 	}
+  
+  Utilities::Geometry::SphericalPoint getCenter() const {return central_point_sphere;}
 
 	/// remove all main halos
 	void clearMainHalos(bool verbose=false);
@@ -198,7 +200,8 @@ public:
 
 	// methods used for use with implanted sources
 
-	short ResetSourcePlane(PosType z,bool nearest, unsigned long GalID=0, PosType *xx=NULL,bool verbose = false);
+  ///  reset the redshift of the source plane
+	short ResetSourcePlane(PosType z,bool nearest=false, unsigned long GalID=0, PosType *xx=NULL,bool verbose = false);
 
 	/// Revert the source redshift to the value it was when the Lens was created.
 	void RevertSourcePlane(){ toggle_source_plane = false;}
@@ -211,13 +214,13 @@ public:
 		}
 	}
 
-	PosType getZmax(){return plane_redshifts.back();}
+	PosType getZmax() const{return plane_redshifts.back();}
 
 	/// print the cosmological parameters
 	void PrintCosmology() { cosmo.PrintCosmology(); }
 	
 	/// returns the critical density at the main lens in Msun/ Mpc^2 for a source at zsource
-	PosType getSigmaCrit(PosType zsource) { return cosmo.SigmaCrit(getZlens(), zsource); }
+	PosType getSigmaCrit(PosType zsource) const{ return cosmo.SigmaCrit(getZlens(), zsource); }
 	
 
   /// returns a const reference to the cosmology so that constant functions can be used, but the cosmological parameters cannot be changed.
@@ -228,10 +231,22 @@ public:
   void TurnFieldOn() { flag_switch_field_off = false ; }
   
   /// get the field min mass :
-  PosType getFieldMinMass() { return field_min_mass ; }
+  PosType getFieldMinMass() const { return field_min_mass ; }
  
   // get the field_Off value :
-  bool getfieldOff() {return flag_switch_field_off ;}
+  bool getfieldOff() const {return flag_switch_field_off ;}
+  
+  /** \brief Add random halos to the light cone according to standard structure formation theory.  A new realization of the light-cone can be made with Lens::resetFieldHalos() after this function is called once.
+   
+   The cone is filled up until the redshift of the current zsource that is stored in the Lens class.  The field is a circular on the sky.  There is no clustering of the halos.
+   */
+  void GenerateFieldHalos(double min_mass /// minimum mass of halos
+                    ,MassFuncType mass_function /// type of mass function
+                    ,double field_of_view  /// in square degrees
+                    ,int Nplanes           /// number of lens planes
+                    ,LensHaloType halo_type = nfw_lens  /// type of halo
+                    ,bool verbose = false
+                );
   
 protected:
   /// field of view in square degrees
@@ -334,7 +349,9 @@ private: /* generation */
   // get the adress of field_plane_redshifts
   std::vector<PosType> & get_field_plane_redshifts () { return field_plane_redshifts ; }
   
+  /// Number of Field Halos
   size_t getNFieldHalos() const {return field_halos.size();}
+  /// Number of Sub Halos
   size_t getNSubHalos() const {return substructure.halos.size();}
   
 private: /* force calculation */

--- a/include/lens_halos.h
+++ b/include/lens_halos.h
@@ -208,6 +208,9 @@ private:
 
 protected:
 
+  // Beyond Rmax the halo will be treated as a point mass.  Between Rsize and Rmax the deflection
+  // and shear are interpolated.  For circularly symmetric lenses Rmax should be equal to Rsize
+  float Rmax;
 
   // make LensHalo uncopyable
   void operator=(LensHalo &){};
@@ -267,10 +270,6 @@ protected:
   /// error message printout
   void error_message1(std::string name,std::string filename);
   
-  // Beyond Rmax the halo will be treated as a point mass.  Between Rsize and Rmax the deflection
-  // and shear are interpolated.  For circularly symmetric lenses Rmax should be equal to Rsize
-  float Rmax;
-  float Rmax_halo;
   
   /// The factor by which Rmax is larger than Rsize
   const float Rmax_to_Rsize_ratio = 1.2;

--- a/include/lens_halos.h
+++ b/include/lens_halos.h
@@ -669,7 +669,7 @@ protected:
  */
 class LensHaloNFW: public LensHalo{
 public:
-  /// Shell constructor that should be avoided
+  /// Shell constructor.  Sets the halo to zero mass
 	LensHaloNFW();
   LensHaloNFW(float my_mass   /// in solar masses
               ,float my_Rsize  /// in Mpc

--- a/include/point.h
+++ b/include/point.h
@@ -135,6 +135,8 @@ struct Point_2d{
     x[1] /= s;
   }
   
+  PosType* data(){return x;}
+  
   PosType x[2];
   PosType & operator[](size_t i){return x[i];}
 };
@@ -519,6 +521,8 @@ struct Point_3d{
     x[1] /= s;
     x[2] /= s;
   }
+  
+  PosType* data(){return x;}
   
   PosType x[3];
   PosType & operator[](size_t i){return x[i];}


### PR DESCRIPTION
Addressing issue #137 

Added a function `Lens::GenerateFieldHalos()` so that the light cone can be filled with a realisation of the expected halos without a parameter file.
![test0](https://user-images.githubusercontent.com/7499429/29242021-7f640d12-7f85-11e7-838e-647047e4c963.png)

Here is some sample code using it:

```
#include <slsimlib.h>
#include <sstream>
#include <iomanip>
#include <omp.h>
#include <thread>
#include <mutex>

#include "gridmap.h"

using namespace std;

int main(int arg,char **argv){
  long seed = -189273;
  
  COSMOLOGY cosmo;
  
  Lens lens(&seed,2);
  
  double minimum_mass = 1.0e10;  // solar masses
  double field_of_view = 0.01;   // in deg^2
  int number_of_lens_planes = 20;
  
  lens.GenerateFieldHalos(minimum_mass,ShethTormen,field_of_view
                          ,number_of_lens_planes,nfw_lens);

  auto sph_center = lens.getCenter();
  Point_2d center(sph_center.phi,sph_center.theta);

  lens.ResetSourcePlane(3);
  
  GridMap grid(&lens,512,center.x,degreesTOradians*2*sqrt(lens.getfov()/pi));
  PixelMap map = grid.writePixelMapUniform(KAPPA);
  map.printFITS("!test0.fits");
  
  for(int i=1 ; i < 2 ; ++i){
    lens.resetFieldHalos();
    GridMap grid(&lens,512,center.x,degreesTOradians*2*sqrt(lens.getfov()/pi));
    grid.writePixelMapUniform(map,KAPPA);
    map.printFITS("!test" + std::to_string(i) + ".fits");
  }
  return 0;
}
```

