### PR TITLE
Added Grid::AddSurfaceBrightness() and GridMap::AddSurfaceBrightness()

### DIFF
--- a/TreeCode_link/grid_maintenance.cpp
+++ b/TreeCode_link/grid_maintenance.cpp
@@ -290,21 +290,44 @@ void Grid::ReShoot(LensHndl lens){
  * returns the sum of the surface brightnesses
  */
 PosType Grid::RefreshSurfaceBrightnesses(SourceHndl source){
-	PosType total=0,tmp;
+  PosType total=0,tmp;
   
   PointList::iterator s_tree_pointlist_it;
   s_tree_pointlist_it.current = (s_tree->pointlist->Top());
-	for(unsigned long i=0;i<s_tree->pointlist->size();++i,--s_tree_pointlist_it){
-		tmp = source->SurfaceBrightness((*s_tree_pointlist_it)->x);
-		(*s_tree_pointlist_it)->surface_brightness = (*s_tree_pointlist_it)->image->surface_brightness
+  for(unsigned long i=0;i<s_tree->pointlist->size();++i,--s_tree_pointlist_it){
+    tmp = source->SurfaceBrightness((*s_tree_pointlist_it)->x);
+    (*s_tree_pointlist_it)->surface_brightness = (*s_tree_pointlist_it)->image->surface_brightness
     = tmp;
-		total += tmp;//*pow( s_tree->pointlist->current->gridsize,2);
-		assert((*s_tree_pointlist_it)->surface_brightness >= 0.0);
-		(*s_tree_pointlist_it)->in_image = (*s_tree_pointlist_it)->image->in_image
+    total += tmp;//*pow( s_tree->pointlist->current->gridsize,2);
+    assert((*s_tree_pointlist_it)->surface_brightness >= 0.0);
+    (*s_tree_pointlist_it)->in_image = (*s_tree_pointlist_it)->image->in_image
     = NO;
-	}
+  }
   
-	return total;
+  return total;
+}
+/**
+ * \brief Recalculate surface brightness just like Grid::RefreshSurfaceBrightness but
+ * the new source is added to any sources that were already there.  
+ *
+ * returns the sum of the surface brightnesses from the new source
+ */
+PosType Grid::AddSurfaceBrightnesses(SourceHndl source){
+  PosType total=0,tmp;
+  
+  PointList::iterator s_tree_pointlist_it;
+  s_tree_pointlist_it.current = (s_tree->pointlist->Top());
+  for(unsigned long i=0;i<s_tree->pointlist->size();++i,--s_tree_pointlist_it){
+    tmp = source->SurfaceBrightness((*s_tree_pointlist_it)->x);
+    (*s_tree_pointlist_it)->surface_brightness += tmp;
+    (*s_tree_pointlist_it)->image->surface_brightness += tmp;
+    total += tmp;//*pow( s_tree->pointlist->current->gridsize,2);
+    assert((*s_tree_pointlist_it)->surface_brightness >= 0.0);
+    (*s_tree_pointlist_it)->in_image = (*s_tree_pointlist_it)->image->in_image
+    = NO;
+  }
+  
+  return total;
 }
 
 PosType Grid::EinsteinArea() const {

--- a/TreeCode_link/gridmap.cpp
+++ b/TreeCode_link/gridmap.cpp
@@ -194,6 +194,19 @@ double GridMap::RefreshSurfaceBrightnesses(SourceHndl source){
   
   return total;
 }
+double GridMap::AddSurfaceBrightnesses(SourceHndl source){
+  PosType total=0,tmp;
+  
+  for(size_t i=0;i <s_points[0].head;++i){
+    tmp = source->SurfaceBrightness(s_points[i].x);
+    s_points[i].surface_brightness += tmp;
+    s_points[i].image->surface_brightness += tmp;
+    total += tmp;
+    s_points[i].in_image = s_points[i].image->in_image = NO;
+  }
+  
+  return total;
+}
 
 void GridMap::ClearSurfaceBrightnesses(){
   

--- a/include/grid_maintenance.h
+++ b/include/grid_maintenance.h
@@ -36,7 +36,9 @@ struct Grid{
   unsigned long PrunePointsOutside(double resolution,double *y,double r_in ,double r_out);
   
   double RefreshSurfaceBrightnesses(SourceHndl source);
+  double AddSurfaceBrightnesses(SourceHndl source);
   double ClearSurfaceBrightnesses();
+  
   unsigned long getNumberOfPoints() const;
   /// area of region with negative magnification
   PosType EinsteinArea() const;

--- a/include/gridmap.h
+++ b/include/gridmap.h
@@ -33,7 +33,24 @@ struct GridMap{
   
     /// reshoot the rays for example when the source plane has been changed
   void ReInitializeGrid(LensHndl lens);
-	double RefreshSurfaceBrightnesses(SourceHndl source);
+  /** Finding
+   * \brief Recalculate surface brightness at every point without changing the positions of the gridmap or any lens properties.
+   *
+   *  Recalculate the surface brightness at all points on the gridmap.
+   * This is useful when changing the source model while preserving changes in the grid.
+   * Both i_tree and s_tree are both changed although only s_tree shows up here.
+   *
+   * returns the sum of the surface brightnesses
+   */
+  double RefreshSurfaceBrightnesses(SourceHndl source);
+  /**
+   * \brief Recalculate surface brightness just like GridMap::RefreshSurfaceBrightness but
+   * the new source is added to any sources that were already there.
+   *
+   * returns the sum of the surface brightnesses from the new source
+   */
+  double AddSurfaceBrightnesses(SourceHndl source);
+
   void ClearSurfaceBrightnesses();
 	size_t getNumberOfPoints() const {return Ngrid_init*Ngrid_init2;}
   

--- a/include/gridmap.h
+++ b/include/gridmap.h
@@ -23,8 +23,6 @@
  *  and thus cannot be used for adaptive mapping or image finding.
  */
 
-//class PixelMap;
-
 struct GridMap{
   
 	GridMap(LensHndl lens,unsigned long N1d,const double center[2],double range);
@@ -33,7 +31,7 @@ struct GridMap{
   
     /// reshoot the rays for example when the source plane has been changed
   void ReInitializeGrid(LensHndl lens);
-  /** Finding
+  /**
    * \brief Recalculate surface brightness at every point without changing the positions of the gridmap or any lens properties.
    *
    *  Recalculate the surface brightness at all points on the gridmap.
@@ -59,7 +57,7 @@ struct GridMap{
 	/// return initial range of gridded region.  This is the distance from the first ray in a row to the last (unlike PixelMap)
 	double getXRange(){return x_range;}
 	double getYRange(){return x_range*axisratio;}
-  // resolution in radians
+  /// resolution in radians, this is range / (N-1)
   double getResolution(){return x_range/(Ngrid_init-1);}
   
   PixelMap writePixelMapUniform(const PosType center[],size_t Nx,size_t Ny,LensingVariable lensvar);
@@ -126,4 +124,4 @@ private:
   static std::mutex grid_mutex;
 };
 
-#endif /* defined(__GLAMER__gridmap__) */
+#endif // defined(__GLAMER__gridmap__)


### PR DESCRIPTION
@DarthLazar you might find these new functions useful.  They allow you to add multiple sources to a Grid or GridMap.  They way I did it before was to have a single source added to the grid, output to a PixelMap and then use Grid::RefreshSurfaceBrightness to replace the source on the grid then add it to the PixelMap again.  I think this will be a more intuitive way of doing it.  Add as many 
sources as you want and then output to a PixelMap.

Grid(Map)::ClearSurfaceBrightness() clears add sources from the Grid.
